### PR TITLE
Fix #1668 guard-stacking regression: route macros can only be applied to functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3186,6 +3186,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function that quietly delegated to its borrowed twin would fail even though
   its output is correct.
 
+### Fixed
+
+- **macros: `#[throttle]`/`#[secured]`/`#[step_up]` above the route macro no
+  longer fail to compile, or silently drop the OpenAPI response schema, once
+  stacked (#1668 regression):** #1668 moved these three guards' runtime
+  checks out of the handler body into each guard's own handler-unique
+  `FromRequestParts` gate — `struct` + `impl`, emitted as a sibling item
+  ahead of the (still single) handler function. Every route macro's own
+  `item` parser (`parse::parse_async_handler`, plus the three guard macros'
+  own parsers, needed when one guard expands above another) only ever
+  accepted a lone `ItemFn`, so a guard macro receiving that two-item output
+  as `item` — any of `#[throttle]`/`#[secured]`/`#[step_up]`/`#[route]`
+  written *above* another guard already using the #1668 gate shape — hit a
+  spurious `route macros can only be applied to functions` compile error.
+  `parse::parse_async_handler_with_preamble` now accepts zero or more
+  leading item definitions ahead of the trailing function, returning them
+  separately so the route/guard macro re-emits that preamble (the gate type
+  the function's new first parameter names) verbatim instead of choking on
+  it.
+
+  Fixing the parse gap surfaced a second, previously-masked bug: with
+  parsing no longer failing first, `#[throttle]`/`#[step_up]` above
+  `#[route]` still resolved to no OpenAPI response schema, because
+  `api_doc::infer_response_body`'s `__autumn_inner`-binding recovery (#1677)
+  only trusts that binding when one of `RESPONSE_REWRITING_GUARD_MARKERS`'s
+  marker consts sits earlier in the *same* handler-body block — and #1668
+  moved `#[throttle]`'s/`#[step_up]`'s marker consts into their gate's
+  `impl` block, out of the body, while `#[secured]`'s marker consts stayed
+  in-body for exactly this reason. Both guards now also leave a dead-code
+  copy of their marker const in the handler body (mirroring `#[secured]`'s
+  existing `role_scope_consts` pattern), restoring the invariant
+  `infer_response_body` relies on — including through stacked guards, where
+  only the innermost binding carries the handler's real return type.
+
+  Regression-proven at both the macro-expansion level (`route.rs`'s
+  existing `route_macro_infers_response_schema_when_throttle_expands_first`
+  / `..._when_step_up_expands_first` / `..._under_stacked_guards_above_route`
+  tests, which predate this fix but never previously reached the code path
+  they exercise) and end to end: `cargo test -p autumn-macros --lib` (1073
+  passed), `cargo fmt --all -- --check`, `cargo clippy -p autumn-macros
+  --all-targets -- -D warnings` all clean.
+
 ## [0.7.0] - 2026-08-23
 
 For a narrative tour of this release, see the

--- a/autumn-macros/src/parse.rs
+++ b/autumn-macros/src/parse.rs
@@ -322,10 +322,51 @@ fn validate_path(path: &LitStr) -> Result<(), TokenStream> {
 /// Returns `Ok(func)` if valid, or a compile error `TokenStream` if not.
 /// Validates: is a function, is async.
 pub fn parse_async_handler(item: TokenStream) -> Result<ItemFn, TokenStream> {
-    let input_fn: ItemFn = syn::parse2(item.clone()).map_err(|_| {
+    let (preamble, input_fn) = parse_async_handler_with_preamble(item)?;
+    if !preamble.is_empty() {
+        return Err(syn::Error::new_spanned(
+            preamble,
+            "route macros can only be applied to functions",
+        )
+        .to_compile_error());
+    }
+    Ok(input_fn)
+}
+
+/// Parse and validate an async handler function from macro input, tolerating
+/// zero or more item definitions ahead of it.
+///
+/// A guard macro that expands before the route macro (e.g.
+/// `#[throttle]`/`#[secured]`/`#[step_up]`, since #1668's pre-body
+/// `FromRequestParts` gate refactor) emits its handler-unique gate `struct`
+/// and its `impl FromRequestParts` block ahead of the modified handler
+/// function, rather than a single function. Route macros need those leading
+/// items re-emitted verbatim (the handler's new first parameter names the
+/// gate type they define), so this returns them separately from the trailing
+/// function instead of failing to parse.
+///
+/// Returns `Ok((preamble, func))` if the input ends in a function — `preamble`
+/// is the empty `TokenStream` when there is no guard gate ahead of it — or a
+/// compile error `TokenStream` if not. Validates: ends in a function, that
+/// function is async.
+pub fn parse_async_handler_with_preamble(
+    item: TokenStream,
+) -> Result<(TokenStream, ItemFn), TokenStream> {
+    let file: syn::File = syn::parse2(item.clone()).map_err(|_| {
         syn::Error::new_spanned(item, "route macros can only be applied to functions")
             .to_compile_error()
     })?;
+
+    let mut items = file.items;
+    let last = items.pop();
+    let Some(syn::Item::Fn(input_fn)) = last else {
+        let trailing = items.into_iter().chain(last);
+        return Err(syn::Error::new_spanned(
+            quote! { #(#trailing)* },
+            "route macros can only be applied to functions",
+        )
+        .to_compile_error());
+    };
 
     if input_fn.sig.asyncness.is_none() {
         return Err(syn::Error::new_spanned(
@@ -335,7 +376,8 @@ pub fn parse_async_handler(item: TokenStream) -> Result<ItemFn, TokenStream> {
         .to_compile_error());
     }
 
-    Ok(input_fn)
+    let preamble = quote! { #(#items)* };
+    Ok((preamble, input_fn))
 }
 
 /// Extract `#[intercept(LayerType)]` attributes from a function's attribute

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -37,8 +37,8 @@ pub fn route_macro(
     };
     let path = route_args.path.clone();
 
-    let mut input_fn = match parse::parse_async_handler(item) {
-        Ok(f) => f,
+    let (preamble, mut input_fn) = match parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
         Err(err) => return err,
     };
 
@@ -256,6 +256,13 @@ pub fn route_macro(
     };
 
     quote! {
+        // A guard macro that already expanded above this route macro (#1668:
+        // #[throttle]/#[secured]/#[step_up]) leaves its handler-unique gate
+        // `struct` + `impl FromRequestParts` here, ahead of the function —
+        // the function's new first parameter names that gate type, so it
+        // must be re-emitted verbatim for the gate type to exist.
+        #preamble
+
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
         // to import axum manually. However, the path resolution in Axum macros makes this impossible
         // natively. Custom compile errors handle the type checks.

--- a/autumn-macros/src/secured.rs
+++ b/autumn-macros/src/secured.rs
@@ -24,7 +24,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ExprLit, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
+use syn::{Expr, ExprLit, Lit, LitStr, Meta, Token, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -118,18 +118,15 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[throttle]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[secured] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     // The session/role check is emitted for the classic forms (`#[secured]`,
     // `#[secured("admin")]`) and whenever a role is required. It is OMITTED for
@@ -312,6 +309,7 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/step_up.rs
+++ b/autumn-macros/src/step_up.rs
@@ -17,7 +17,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{ItemFn, LitStr, parse_quote};
+use syn::{LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -196,17 +196,15 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(v) => v,
         Err(err) => return err.to_compile_error(),
     };
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[step_up]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[step_up] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     let max_age_tokens = max_age_opt.map_or_else(
         || quote! { ::core::option::Option::None },
@@ -329,13 +327,29 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
+    // A dead-code marker mirroring the real `__AUTUMN_STEP_UP_MAX_AGE` const
+    // the gate carries (#1668 moved the runtime check itself into the gate's
+    // own `impl` block, out of the handler body). `api_doc::infer_response_body`
+    // recovers a guard-rewritten handler's real return type from the
+    // `__autumn_inner` binding below, but only accepts that binding when one
+    // of `RESPONSE_REWRITING_GUARD_MARKERS` is present earlier in the *same*
+    // block — so `#[step_up]` needs its own marker in-body too, exactly like
+    // `#[secured]`'s role/scope consts, or a route stacking `#[step_up]`
+    // above `#[route]` silently loses its OpenAPI response schema (#1677).
+    let body_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_STEP_UP_MAX_AGE: ::core::option::Option<u64> = #max_age_tokens;
+    };
+
     input_fn.block = syn::parse_quote! {
         {
+            #body_marker
             #original_response
         }
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/throttle.rs
+++ b/autumn-macros/src/throttle.rs
@@ -21,7 +21,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ItemFn, Lit, LitInt, LitStr, parse_quote};
+use syn::{Expr, Lit, LitInt, LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -251,18 +251,15 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[throttle]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[throttle] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     let fn_name = input_fn.sig.ident.clone();
     let fn_name_str = fn_name.to_string();
@@ -437,13 +434,29 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
+    // A dead-code marker mirroring the real `__AUTUMN_THROTTLE_ROUTE_ID` const
+    // the gate carries (#1668 moved the runtime check itself into the gate's
+    // own `impl` block, out of the handler body). `api_doc::infer_response_body`
+    // recovers a guard-rewritten handler's real return type from the
+    // `__autumn_inner` binding below, but only accepts that binding when one
+    // of `RESPONSE_REWRITING_GUARD_MARKERS` is present earlier in the *same*
+    // block — so `#[throttle]` needs its own marker in-body too, exactly like
+    // `#[secured]`'s `role_scope_consts`, or a route stacking `#[throttle]`
+    // above `#[route]` silently loses its OpenAPI response schema (#1677).
+    let body_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_THROTTLE_ROUTE_ID: &str = #fn_name_str;
+    };
+
     input_fn.block = syn::parse_quote! {
         {
+            #body_marker
             #original_response
         }
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }


### PR DESCRIPTION
## Summary

`trunk-dev` is currently red on all three `Test` platforms (ubuntu/windows/macos-latest) — see [run 33909595295](https://github.com/autumn-foundation/autumn/actions/runs/33909595295) on 66106a5c, the tip at the time this was found. This blocks CI on every open PR against `trunk-dev`, unrelated to whatever that PR itself changes (confirmed on #2510, which only touches `hot-upgrade`).

Root cause: [#2488](https://github.com/autumn-foundation/autumn/pull/2488) (#1668) moved `#[throttle]`/`#[secured]`/`#[step_up]`'s runtime checks out of the handler body into each guard's own handler-unique `FromRequestParts` gate — a `struct` + `impl`, emitted as a sibling item ahead of the (still single) handler function — instead of a single modified function. Every route/guard macro's own `item` parser (`parse::parse_async_handler`, plus the three guard macros' own parsers, needed when one guard expands above another) only ever accepted a lone `ItemFn`, so a guard macro receiving that two-item output as `item` — any of `#[throttle]`/`#[secured]`/`#[step_up]`/`#[route]` written *above* another guard already using the #1668 gate shape — hit a spurious `route macros can only be applied to functions` compile error.

## Fix

- `parse::parse_async_handler_with_preamble` now accepts zero or more leading item definitions ahead of the trailing function, returning them separately so the route/guard macro re-emits that preamble (the gate type the function's new first parameter names) verbatim instead of choking on it.
- Fixing the parse gap surfaced a second, previously-masked bug: with parsing no longer failing first, `#[throttle]`/`#[step_up]` above `#[route]` still resolved to no OpenAPI response schema, because `api_doc::infer_response_body`'s `__autumn_inner`-binding recovery (#1677) only trusts that binding when one of `RESPONSE_REWRITING_GUARD_MARKERS`'s marker consts sits earlier in the *same* handler-body block — and #1668 moved `#[throttle]`'s/`#[step_up]`'s marker consts into their gate's `impl` block, out of the body, while `#[secured]`'s marker consts stayed in-body for exactly this reason. Both guards now also leave a dead-code copy of their marker const in the handler body (mirroring `#[secured]`'s existing `role_scope_consts` pattern), restoring the invariant `infer_response_body` relies on — including through stacked guards, where only the innermost binding carries the handler's real return type.

This surfaced via `route.rs`'s existing `route_macro_infers_response_schema_when_throttle_expands_first` / `..._when_step_up_expands_first` / `..._under_stacked_guards_above_route` tests, which predate this fix but were failing on `trunk-dev` and had never previously reached the code path they exercise (the parse error masked the schema-recovery bug underneath it).

## Test plan

- [x] `cargo test -p autumn-macros --lib` — 1073 passed, 0 failed
- [x] `cargo test -p autumn-web --test integration_tests -- secured_route:: step_up_route:: throttle_route:: authorization_integration::` — 47 passed, 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p autumn-macros --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJy5FusFsz4hLGr5BFZzBb

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJy5FusFsz4hLGr5BFZzBb)_