### PR TITLE
🚦 CI: shard the test suite across runners (2h27m → ~1h27m measured, cold cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,45 @@ jobs:
       - name: cargo-deny check (licenses, sources; sqlite backend graph)
         run: cargo deny --config deny-sqlite.toml check licenses sources
 
+  # ---------------------------------------------------------------------------
+  # THE TEST SUITE IS SHARDED ACROSS RUNNERS.
+  #
+  # It used to be one `Test (<os>)` job per OS that ran, in sequence: the whole
+  # workspace suite, then eight feature-flipped re-builds, then the Docker sweep.
+  # On the 2026-08-26 trunk run that job was 128 minutes on Windows and 92 on
+  # macOS, and it WAS the critical path of CI (2h27m end to end). Measured from
+  # that run's logs, the time went:
+  #
+  #                             ubuntu    macos   windows
+  #   compile (cargo test -W)    11.6m    29.1m     27.0m
+  #   run: integration_tests     14.4m    17.4m     46.8m
+  #     ...of which trybuild     10.3m    12.0m     37.1m   <-- ONE #[test]
+  #   run: 142 other binaries     1.9m     5.0m      4.7m
+  #   gated feature re-builds    25.0m    38.3m     44.0m
+  #
+  # Two facts drive the split below:
+  #
+  #   1. `compile_fail::*` (trybuild) was 71-79% of the consolidated
+  #      `integration_tests` binary's run time, and it is the TAIL -- the binary
+  #      finished 0.2s after trybuild did, on every OS. Each case shells out a
+  #      nested `cargo` build, trybuild serialises them behind its project-dir
+  #      lock, and libtest cannot split a single `#[test]`. So it does not get
+  #      faster by adding threads; it gets faster by moving to its own runners.
+  #   2. The eight gated feature lanes are INDEPENDENT re-builds of autumn-web
+  #      under disjoint feature sets. Run in sequence they are ~44 minutes of
+  #      pure recompilation on Windows; run side by side they are ~11.
+  #
+  # What is NOT sharded, deliberately: everything still runs `cargo test
+  # --workspace`, so every shard sees the same globally-unified feature set that
+  # decides which `#[cfg]`-gated trybuild fixtures exist. Narrowing a shard to
+  # `-p autumn-web --test integration_tests` would silently drop fixtures.
+  # The duplicated compile that costs is the price of that guarantee.
+  #
+  # Adding a shard: add it to the matrix AND to `test-gate`'s `needs`. Branch
+  # protection should require ONLY `Test suite` (the `test-gate` job) -- it is
+  # the one check name that stays stable as shards are added and removed.
+  # ---------------------------------------------------------------------------
+
   test:
     name: Test (${{ matrix.os }})
     needs: [lint, meta]
@@ -326,8 +365,8 @@ jobs:
       - name: Free disk space (Linux)
         if: runner.os == 'Linux'
         run: |
-          # The full workspace build (especially the wide-feature +
-          # Postgres-container step below) sits near the runner's disk
+          # The full workspace build (and, in `test-docker`, the wide-feature
+          # Postgres-container sweep on top of it) sits near the runner's disk
           # ceiling; a cold-cache PR build tips it over ("No space left on
           # device"). Reclaim the preinstalled toolchains a Rust build never
           # uses before the cache is restored.
@@ -345,10 +384,130 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.8
         continue-on-error: true
       - name: Run tests
-        run: cargo test --workspace
+        # `--skip compile_fail::` hands the trybuild module to the `trybuild`
+        # job below. It is a substring skip and `compile_fail::` is the module
+        # path of every test in it, so the two are exhaustive by construction:
+        # what this job skips is exactly what that job's four shards run.
+        run: |
+          cargo test --workspace -- --skip compile_fail::
+
+  trybuild:
+    name: Trybuild ${{ matrix.shard }} (${{ matrix.os }})
+    needs: [lint, meta]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        # The four shards partition `compile_fail::` exactly. `pass_a`/`pass_b`
+        # are two halves of one fixture list (see the comment on
+        # `compile_pass_tests_a`); `rest` is everything else in the module --
+        # the feature-gated registries and the two guide-consistency tests,
+        # which together measured under a second.
+        shard: [fail, pass_a, pass_b, rest]
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && fromJSON(needs.meta.outputs.heavy_runs_on) || matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # The full workspace build (and, in `test-docker`, the wide-feature
+          # Postgres-container sweep on top of it) sits near the runner's disk
+          # ceiling; a cold-cache PR build tips it over ("No space left on
+          # device"). Reclaim the preinstalled toolchains a Rust build never
+          # uses before the cache is restored.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache \
+            /usr/local/share/boost \
+            /usr/local/lib/node_modules \
+            /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+        continue-on-error: true
+        # Deliberately NO per-shard cache key: every shard of this job runs the
+        # identical `cargo test --workspace` build and differs only in which
+        # tests it then runs, so they should share one warm target dir. (The
+        # default key already varies by job name and by runner OS/arch.)
+      - name: Run the trybuild shard
+        # `cargo test --workspace` (not `-p autumn-web --test integration_tests`)
+        # on purpose: the fixtures registered by `compile_fail.rs` are
+        # `#[cfg(feature = ...)]`-gated, so the set that exists depends on the
+        # GLOBALLY unified feature resolution of a workspace build. Narrowing
+        # the package selection here would quietly compile fewer of them out and
+        # still report green. Every other test in the workspace is filtered out
+        # by the shard's own filter, so the extra targets only cost their link.
+        #
+        # `assert_ran` for the reason the TLS/ACME lanes give: `cargo test` exits
+        # 0 when a filter matches NOTHING, so a rename in `compile_fail.rs` would
+        # otherwise leave a shard green having compiled nothing at all.
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.shard }}" in
+            fail)   filter=(compile_fail::compile_fail_tests) ;;
+            pass_a) filter=(compile_fail::compile_pass_tests_a) ;;
+            pass_b) filter=(compile_fail::compile_pass_tests_b) ;;
+            rest)   filter=(compile_fail::
+                      --skip compile_fail::compile_fail_tests
+                      --skip compile_fail::compile_pass_tests_a
+                      --skip compile_fail::compile_pass_tests_b) ;;
+          esac
+          cargo test --workspace -- "${filter[@]}" | tee "${RUNNER_TEMP}/trybuild.log"
+          grep -qE 'test result: ok\. [1-9][0-9]* passed' "${RUNNER_TEMP}/trybuild.log" \
+            || { echo "::error::trybuild shard ${{ matrix.shard }} ran no tests — the filter no longer matches anything in compile_fail.rs"; exit 1; }
+
+  test-features:
+    name: Test ${{ matrix.lane }} (${{ matrix.os }})
+    needs: [lint, meta]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each lane is a feature set that `cargo test --workspace` does not
+        # compile, so each is its own re-build of autumn-web. They share nothing
+        # but the source tree, which is why they belong on separate runners.
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        lane: [markdown, inbound-mail, i18n, plugin-sandbox, system-tests]
+        include:
+          # Linux-only lanes, unchanged from the `if: runner.os == 'Linux'`
+          # guards they used to carry inline. Each step's own comment says why.
+          - { os: ubuntu-latest, lane: redis-tls }
+          - { os: ubuntu-latest, lane: tls }
+          - { os: ubuntu-latest, lane: acme }
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && fromJSON(needs.meta.outputs.heavy_runs_on) || matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # The full workspace build (and, in `test-docker`, the wide-feature
+          # Postgres-container sweep on top of it) sits near the runner's disk
+          # ceiling; a cold-cache PR build tips it over ("No space left on
+          # device"). Reclaim the preinstalled toolchains a Rust build never
+          # uses before the cache is restored.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache \
+            /usr/local/share/boost \
+            /usr/local/lib/node_modules \
+            /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+        continue-on-error: true
+        with:
+          # One target dir per feature set; see the note on the trybuild job.
+          key: ${{ matrix.lane }}
       - name: Run markdown-gated tests (user-content sanitizer)
-        # `markdown` is not a default feature, so the `cargo test --workspace`
-        # above compiles neither the stored-XSS regression corpus
+        if: matrix.lane == 'markdown'
+        # `markdown` is not a default feature, so the `test` job's `cargo test
+        # --workspace` compiles neither the stored-XSS regression corpus
         # (`autumn/tests/integration/rich_text.rs`, gated on
         # `markdown` + `maud`) nor the `markdown::user_content` doctests. That
         # corpus IS the safety guarantee for user-submitted rich text
@@ -358,6 +517,7 @@ jobs:
           cargo test -p autumn-web --features markdown --lib markdown::
           cargo test -p autumn-web --features markdown --doc markdown::
       - name: Run inbound-mail-gated tests (untrusted MIME parsing)
+        if: matrix.lane == 'inbound-mail'
         # `inbound-mail` and its provider aliases are not default features, so
         # `cargo test --workspace` compiles neither `inbound_mail`'s in-module
         # suite nor `autumn/tests/integration/inbound_mail_integration.rs`
@@ -368,19 +528,21 @@ jobs:
           cargo test -p autumn-web --features "inbound-mail,inbound-mailgun,inbound-ses,mail" --lib inbound_mail
           cargo test -p autumn-web --features "inbound-mail,inbound-mailgun,inbound-ses,mail,test-support" --test integration_tests inbound_mail
       - name: Run i18n-gated tests (translatable model fields)
-        # `i18n` is not a default feature, so the `cargo test --workspace` above
-        # compiles neither `i18n::translatable`'s in-module suite nor the two
+        if: matrix.lane == 'i18n'
+        # `i18n` is not a default feature, so the `test` job's `cargo test
+        # --workspace` compiles neither `i18n::translatable`'s in-module suite nor the two
         # `#![cfg(feature = "i18n")]` integration modules. Those are the whole
         # behavioural proof for #1384 — per-locale persistence, the fallback
         # walk, the documented sentinel, and the ambient-locale request path —
         # so they have to run in a lane that blocks merge rather than only in
         # the (non-blocking, Codecov-driven) coverage job. The Docker-gated
         # round-trip tests in `translatable_model` are swept separately by the
-        # "Run Docker-dependent tests" step below.
+        # `test-docker` job.
         run: |
           cargo test -p autumn-web --features i18n --lib i18n::
           cargo test -p autumn-web --features "i18n,test-support" --test integration_tests translatable
       - name: Run plugin-sandbox tests (untrusted-plugin containment)
+        if: matrix.lane == 'plugin-sandbox'
         # `plugin-sandbox` is not a default feature, so `cargo test --workspace`
         # compiles neither the sandbox's in-module suites nor
         # `autumn/tests/integration/plugin_sandbox.rs`. That integration module IS
@@ -397,9 +559,24 @@ jobs:
           cargo test -p autumn-web --features "plugin-sandbox,test-support" --test integration_tests plugin_sandbox
           cargo test -p autumn-web --features plugin-sandbox --doc plugin_sandbox
 
+      - name: Run system-test harness (non-browser) tests
+        if: matrix.lane == 'system-tests'
+        # `system-tests` is not a default feature. The `test` job's `cargo test
+        # --workspace` happens to compile it today only because `example-e2e` depends
+        # on `autumn-web` with that feature and workspace feature unification
+        # turns it on — accidental coverage that would vanish silently if that
+        # one dependency were ever dev-scoped or dropped. Name it explicitly so
+        # the harness's own tests (browser resolution, transient-CDP retry
+        # loop, `SystemTest::layer`) stay covered on purpose. The `#[ignore]`d
+        # browser tests need Chromium and run in publish-gate.yml's
+        # browser-provisioned job.
+        run: |
+          cargo test -p autumn-web --features system-tests --lib system_test::
+          cargo test -p autumn-web --features system-tests --test integration_tests system_test_api
       - name: Run redis-TLS-gated tests (rediss:// CryptoProvider guard)
-        # `redis` and `ws` are not `autumn-web` default features. The
-        # workspace `cargo test` above happens to compile this suite anyway,
+        if: matrix.lane == 'redis-tls'
+        # `redis` and `ws` are not `autumn-web` default features. The `test`
+        # job's workspace `cargo test` happens to compile this suite anyway,
         # because resolver-3 feature unification pulls `redis` in from
         # `autumn-cache-redis`/`autumn-cli` and `ws` from the `reddit-clone`
         # example — a coincidence of what other members want, not anything
@@ -417,7 +594,6 @@ jobs:
         # Linux only: the assertions are about process-global state and fork
         # isolation, neither of which is platform-specific, and `rusty_fork`
         # re-execs the test binary — cheapest on the fast runner.
-        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           assert_ran() {
@@ -431,8 +607,9 @@ jobs:
             | tee "${RUNNER_TEMP}/cache-redis.log"
           assert_ran "${RUNNER_TEMP}/cache-redis.log" "autumn-cache-redis unit tests"
       - name: Run direct-TLS (HTTPS) tests
-        # `tls` is not a default feature, so the workspace `cargo test` above
-        # compiles neither `tls`'s in-module suite nor the `[server.tls]`
+        if: matrix.lane == 'tls'
+        # `tls` is not a default feature, so the `test` job's workspace `cargo
+        # test` compiles neither `tls`'s in-module suite nor the `[server.tls]`
         # integration modules. Those are the behavioural proof for #1603 — the
         # listener itself (`tls_serving`) plus the app-surface parity the ACs
         # name: the framework probes, the inbound request timeout, SSE, `wss://`
@@ -452,7 +629,6 @@ jobs:
         # checked for a non-zero pass count: `cargo test` exits 0 when a filter
         # matches NOTHING, so a cfg drift that stopped compiling these modules
         # in would otherwise leave this step green with zero HTTPS coverage.
-        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           assert_ran() {
@@ -469,26 +645,26 @@ jobs:
             --test integration_tests tls_app_surface:: | tee "${RUNNER_TEMP}/tls-surface.log"
           assert_ran "${RUNNER_TEMP}/tls-surface.log" "tls_app_surface"
       - name: Run ACME-gated tests (certificate provisioning + renewal)
-        # `acme` is not a default feature either, so the workspace `cargo test`
-        # above compiles neither `acme`'s in-module suite nor `acme_end_to_end`.
+        if: matrix.lane == 'acme'
+        # `acme` is not a default feature either, so the `test` job's workspace
+        # `cargo test` compiles neither `acme`'s in-module suite nor `acme_end_to_end`.
         # That suite is the behavioural proof for #1608 — first-boot issuance and
         # the HTTP→HTTPS redirect, a forced near-expiry rotation with no restart,
         # a restart reusing the stored account and certificate, and a failed order
         # reaching health plus the error-reporting seam — driven through a real
         # `instant-acme` client against an in-process fake CA (`acme_fake_ca`).
-        # No Docker and no network, so it belongs in this fast lane rather than
-        # the Docker sweep below.
+        # No Docker and no network, so it belongs in this lane rather than the
+        # `test-docker` job.
         #
-        # The `tls` half of this path is covered by the direct-TLS step above;
+        # The `tls` half of this path is covered by the `tls` lane;
         # `acme` implies `tls`, so this step deliberately runs only the ACME
         # suites rather than rebuilding and re-running those.
         #
-        # Linux only, and `assert_ran` for the same two reasons the step above
+        # Linux only, and `assert_ran` for the same two reasons the `tls` lane
         # gives: the renewal tests wait on real elapsed time, and `cargo test`
         # exits 0 when a filter matches NOTHING — so a cfg drift that stopped
         # compiling these modules in would otherwise leave this step green with
         # zero ACME coverage.
-        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
           assert_ran() {
@@ -501,21 +677,35 @@ jobs:
           cargo test -p autumn-web --features acme \
             --test integration_tests acme_end_to_end:: | tee "${RUNNER_TEMP}/acme-e2e.log"
           assert_ran "${RUNNER_TEMP}/acme-e2e.log" "acme_end_to_end"
-      - name: Run system-test harness (non-browser) tests
-        # `system-tests` is not a default feature. The `cargo test --workspace`
-        # above happens to compile it today only because `example-e2e` depends
-        # on `autumn-web` with that feature and workspace feature unification
-        # turns it on — accidental coverage that would vanish silently if that
-        # one dependency were ever dev-scoped or dropped. Name it explicitly so
-        # the harness's own tests (browser resolution, transient-CDP retry
-        # loop, `SystemTest::layer`) stay covered on purpose. The `#[ignore]`d
-        # browser tests need Chromium and run in publish-gate.yml's
-        # browser-provisioned job.
-        run: |
-          cargo test -p autumn-web --features system-tests --lib system_test::
-          cargo test -p autumn-web --features system-tests --test integration_tests system_test_api
-      - name: Install Postgres client tools (Linux)
+
+  test-docker:
+    name: Docker-dependent tests
+    needs: [lint, meta]
+    runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Free disk space (Linux)
         if: runner.os == 'Linux'
+        run: |
+          # The full workspace build (and, in `test-docker`, the wide-feature
+          # Postgres-container sweep on top of it) sits near the runner's disk
+          # ceiling; a cold-cache PR build tips it over ("No space left on
+          # device"). Reclaim the preinstalled toolchains a Rust build never
+          # uses before the cache is restored.
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /opt/hostedtoolcache \
+            /usr/local/share/boost \
+            /usr/local/lib/node_modules \
+            /usr/share/swift
+          sudo docker image prune --all --force || true
+          df -h
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2.7.8
+        continue-on-error: true
+      - name: Install Postgres client tools (Linux)
         run: |
           # The offsite-backup round-trip below drives `autumn db backup`, which
           # shells out to the HOST `pg_dump`/`pg_restore`. ubuntu-latest does not
@@ -532,7 +722,6 @@ jobs:
           pg_restore --version
           ssh -V
       - name: Run Docker-dependent tests
-        if: runner.os == 'Linux'
         timeout-minutes: 45
         run: |
           cargo test -p autumn-web --test db_hooks_lifecycle -- --ignored
@@ -642,9 +831,27 @@ jobs:
           # installed above.
           cargo test -p autumn-cli --test deploy_e2e -- --ignored
 
+
+  test-gate:
+    name: Test suite
+    # The stable, shard-count-independent name for branch protection and for
+    # downstream `needs:`. It fails if ANY shard failed or was cancelled; a
+    # `needs:` alone would let a skipped shard pass silently.
+    needs: [test, trybuild, test-features, test-docker]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check shard results
+        run: |
+          results='${{ join(needs.*.result, " ") }}'
+          echo "shard results: $results"
+          for r in $results; do
+            [ "$r" = "success" ] || { echo "::error::a test shard did not succeed ($results)"; exit 1; }
+          done
+
   coverage:
     name: Coverage
-    needs: [test, meta]
+    needs: [test-gate, meta]
     runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
     steps:
       - uses: actions/checkout@v7
@@ -902,7 +1109,7 @@ jobs:
   # the preemption budget + job timeout bound the state-space search.
   loom:
     name: Loom
-    needs: [test, meta]
+    needs: [test-gate, meta]
     runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.7.8
         continue-on-error: true
+        with:
+          # This job and every `trybuild` shard run the IDENTICAL `cargo test
+          # --workspace` build and differ only in which tests they then run, so
+          # they share one cache entry instead of five near-identical copies.
+          # This job is the only writer (the shards set `save-if: false`).
+          shared-key: workspace-test
       - name: Run tests
         # `--skip compile_fail::` hands the trybuild module to the `trybuild`
         # job below. It is a substring skip and `compile_fail::` is the module
@@ -428,10 +434,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.7.8
         continue-on-error: true
-        # Deliberately NO per-shard cache key: every shard of this job runs the
-        # identical `cargo test --workspace` build and differs only in which
-        # tests it then runs, so they should share one warm target dir. (The
-        # default key already varies by job name and by runner OS/arch.)
+        with:
+          # Restore the entry the `test` job writes: same build, same features.
+          shared-key: workspace-test
+          # RESTORE ONLY. Four shards racing to upload the same multi-GB target
+          # dir buys nothing, and on windows-latest that upload is what killed
+          # `Trybuild pass_a` in run 8362 — the shard itself had already passed
+          # at 53m, then the cache-save post step ran 47 more minutes and the
+          # runner dropped the job. `test` is the single writer.
+          save-if: false
       - name: Run the trybuild shard
         # `cargo test --workspace` (not `-p autumn-web --test integration_tests`)
         # on purpose: the fixtures registered by `compile_fail.rs` are
@@ -459,6 +470,18 @@ jobs:
           cargo test --workspace -- "${filter[@]}" | tee "${RUNNER_TEMP}/trybuild.log"
           grep -qE 'test result: ok\. [1-9][0-9]* passed' "${RUNNER_TEMP}/trybuild.log" \
             || { echo "::error::trybuild shard ${{ matrix.shard }} ran no tests — the filter no longer matches anything in compile_fail.rs"; exit 1; }
+      - name: Drop the trybuild scratch tree
+        if: always()
+        # trybuild compiles every case as a real crate under
+        # `target/tests/trybuild`; that tree measures ~16 GB after a full
+        # `compile_pass` shard. It is pure scratch — regenerated each run,
+        # never a build input — but no cache action's prune knows that layout,
+        # so leaving it in place makes any post-run upload try to ship all of
+        # it. `save-if: false` above already prevents that; this keeps the
+        # disk bounded too, and keeps the hazard from returning silently if
+        # anyone ever flips that flag back.
+        shell: bash
+        run: rm -rf target/tests
 
   test-features:
     name: Test ${{ matrix.lane }} (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,14 @@ jobs:
           # they share one cache entry instead of five near-identical copies.
           # This job is the only writer (the shards set `save-if: false`).
           shared-key: workspace-test
+          # Save the target dir even when the test STEP fails. rust-cache skips
+          # its save on a failed job by default, and because this job is the
+          # sole writer of the shared key, a red `test` means no shard ever
+          # gets a warm cache — exactly when a warm cache matters most, since
+          # a red suite is what you iterate against. What is being cached is
+          # compiled artifacts; their validity does not depend on whether the
+          # tests that ran afterwards passed.
+          cache-on-failure: true
       - name: Run tests
         # `--skip compile_fail::` hands the trybuild module to the `trybuild`
         # job below. It is a substring skip and `compile_fail::` is the module

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,9 +865,17 @@ jobs:
 
   test-gate:
     name: Test suite
-    # The stable, shard-count-independent name for branch protection and for
-    # downstream `needs:`. It fails if ANY shard failed or was cancelled; a
-    # `needs:` alone would let a skipped shard pass silently.
+    # The stable, shard-count-independent name for BRANCH PROTECTION. It fails
+    # if any shard failed or was cancelled; a `needs:` alone would let a skipped
+    # shard pass silently.
+    #
+    # Nothing else should hang off this job. Anything with `needs: [test-gate]`
+    # inherits two properties it almost certainly does not want: it cannot start
+    # until the SLOWEST shard finishes (the Windows trybuild shard, ~57m), and
+    # it is SKIPPED whenever any one of the ~34 shard jobs is red — and a
+    # skipped required check can never be satisfied, so the PR stops being
+    # mergeable even once the real failure is understood. `coverage` and `loom`
+    # were briefly wired here and hit exactly that; they depend on `test`.
     needs: [test, trybuild, test-features, test-docker]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
@@ -882,7 +890,12 @@ jobs:
 
   coverage:
     name: Coverage
-    needs: [test-gate, meta]
+    # `test`, NOT `test-gate`: coverage instruments the workspace suite, so the
+    # `test` job is the only thing it actually depends on. Hanging it off the
+    # aggregate would make an unrelated red shard (a feature lane, a trybuild
+    # shard) skip coverage entirely, and would delay its start until the
+    # slowest shard finished. See the note on `test-gate`.
+    needs: [test, meta]
     runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
     steps:
       - uses: actions/checkout@v7
@@ -1140,7 +1153,8 @@ jobs:
   # the preemption budget + job timeout bound the state-space search.
   loom:
     name: Loom
-    needs: [test-gate, meta]
+    # `test`, NOT `test-gate` — same reasoning as `coverage` above.
+    needs: [test, meta]
     runs-on: ${{ fromJSON(needs.meta.outputs.heavy_runs_on) }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,7 +843,7 @@ jobs:
     steps:
       - name: Check shard results
         run: |
-          results='${{ join(needs.*.result, " ") }}'
+          results='${{ join(needs.*.result, ' ') }}'
           echo "shard results: $results"
           for r in $results; do
             [ "$r" = "success" ] || { echo "::error::a test shard did not succeed ($results)"; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1322,6 +1322,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ci:** the test suite is now **sharded across runners** instead of running as
+  one job per OS. On the 2026-08-26 trunk run the `Test (windows-latest)` job
+  alone was 128 minutes and *was* the critical path of a 2h27m CI run. Measured
+  from that run's logs, two things dominated. First, `compile_fail::` — the
+  trybuild module — accounted for 37.1 of the 46.8 minutes the consolidated
+  `integration_tests` binary spent running on Windows (10.3/14.4 on Linux,
+  12.0/17.4 on macOS), and it was the *tail*: the binary finished 0.2s after
+  trybuild did, on every OS. Each case shells out a nested `cargo` build and
+  trybuild serialises them behind its project-dir lock, so it cannot be sped up
+  with more threads — only with more runners. Second, the eight non-default
+  feature lanes (markdown, inbound-mail, i18n, plugin-sandbox, system-tests,
+  redis-tls, tls, acme) ran in sequence in that same job, ~44 minutes of pure
+  recompilation on Windows, despite being independent builds that share
+  nothing. The `test` job is now four job families that run side by side:
+  `test` (the workspace suite, with `compile_fail::` skipped), `trybuild` (four
+  shards), `test-features` (one job per feature set) and `test-docker` (the
+  Linux testcontainer sweep). `compile_pass_tests` was split into
+  `compile_pass_tests_a` / `_b` — a disjoint split of the same fixture list, no
+  fixture added or removed — so the expensive half can occupy two runners.
+  Every shard still runs `cargo test --workspace`, deliberately: the trybuild
+  fixture list is `#[cfg(feature = ...)]`-gated, so narrowing a shard to `-p
+  autumn-web --test integration_tests` would silently compile fewer fixtures
+  and still report green. Each shard asserts a non-zero pass count, because
+  `cargo test` exits 0 when a filter matches nothing. **Branch protection must
+  be repointed** from the per-OS `Test (…)` checks to the new `Test suite`
+  (`test-gate`) check, which aggregates every shard and is the one name that
+  stays stable as shards are added or removed.
 - **plugin-conformance:** **Breaking:** `plugin_conformance::ConformanceConfig`
   gains a `contract` field and is now `#[non_exhaustive]`, so it can no longer
   be built with a struct literal — use `ConformanceConfig::new(name)` and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1323,7 +1323,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **ci:** the test suite is now **sharded across runners** instead of running as
-  one job per OS. On the 2026-08-26 trunk run the `Test (windows-latest)` job
+  one job per OS [no-plugin] — this is CI scheduling only; it adds no framework
+  surface an agent could reach for, and the one behavioural note for humans
+  editing tests lives in CLAUDE.md rather than the plugin. On the 2026-08-26 trunk run the `Test (windows-latest)` job
   alone was 128 minutes and *was* the critical path of a 2h27m CI run. Measured
   from that run's logs, two things dominated. First, `compile_fail::` — the
   trybuild module — accounted for 37.1 of the 46.8 minutes the consolidated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,38 @@ separate, deliberate step the user asks for by name.
 
 ---
 
+## CI test sharding
+
+`.github/workflows/ci.yml` runs the suite as four sibling job families rather
+than one job per OS. Which one a test lands in follows from how it is written,
+so it is usually automatic:
+
+| Job | What it runs |
+| --- | --- |
+| `test` | `cargo test --workspace -- --skip compile_fail::` — the default lane |
+| `trybuild` | `compile_fail::*` only, split into four shards |
+| `test-features` | one job per non-default feature set (markdown, i18n, tls, …) |
+| `test-docker` | the Linux `#[ignore]`d Docker/testcontainer sweep |
+
+Two rules matter when editing tests:
+
+- **`compile_fail.rs` is partitioned by test-function name.** A new `#[test]`
+  in that module runs in the `rest` shard automatically. A **renamed** one does
+  not: `fail`, `pass_a` and `pass_b` name their functions explicitly and assert
+  a non-zero pass count, so a rename fails that shard loudly rather than
+  silently skipping it. Rename the shard filter in `ci.yml` alongside.
+- **Branch protection should require `Test suite`** (the `test-gate` job), not
+  the individual shards — it is the one check name that survives adding or
+  removing a shard.
+
+The split is not cosmetic: on the 2026-08-26 trunk run, `compile_fail::` alone
+was 37 of the 47 minutes the consolidated `integration_tests` binary spent
+running on Windows, and it was the tail everything else waited on. Its cases
+each shell out a nested `cargo` build and trybuild serialises them behind a
+project-dir lock, so the only thing that makes it faster is more runners.
+
+---
+
 ## Integration Test Layout Guidelines
 
 To minimize Cargo compilation and linking overhead (avoiding 100+ separate binaries), the workspace uses a consolidated test binary structure for both the `autumn` and `autumn-cli` packages.
@@ -53,7 +85,7 @@ The default approach for new tests is to add them to the consolidated binary so 
 
 ##### Docker / testcontainer DB tests run automatically in CI
 
-The CI "Run Docker-dependent tests" step (Linux) sweeps every `#[ignore]`d
+The CI `test-docker` job (Linux) sweeps every `#[ignore]`d
 test that compiles into the `autumn` consolidated `integration_tests` binary with
 `--features "test-support,offline-sync"` (a bare `--ignored` run), so a new
 house-pattern testcontainer DB test — `#[ignore = "requires Docker (testcontainers)"]` in a `db`-gated (or ungated) module — executes in CI with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,16 @@ Chromium `system-tests` lanes (those run in dedicated CI jobs); `cargo test -p
 <pkg>` remains fine for iterating on a single crate — just run
 `./scripts/pre-push-check.sh` before you push.
 
+In CI that blocking gate is **sharded across runners**, so a red PR points at
+one of several jobs rather than a single `Test (<os>)`: `test` runs the
+workspace suite, `trybuild` runs `compile_fail::` in four shards,
+`test-features` runs one job per non-default feature set, and `test-docker`
+runs the Linux testcontainer sweep. `Test suite` (`test-gate`) is the
+aggregate check that must be green. Nothing about how you *write* a test
+changes — see CLAUDE.md "CI test sharding" for the two cases that do matter
+(renaming a `compile_fail.rs` test function, and what branch protection should
+require).
+
 ## Generator conformance gate
 
 Autumn's headline DX promise is that `autumn new` and `autumn generate` emit

--- a/autumn/tests/integration/compile_fail.rs
+++ b/autumn/tests/integration/compile_fail.rs
@@ -351,8 +351,8 @@ fn agent_authority_compile_fail_tests() {
 
 /// The `#[agent_operable]` compile-*pass* half (#1691), for the reason its
 /// compile-fail sibling has its own test: a self-contained feature worth
-/// running on its own, and two fewer lines in a `compile_pass_tests` that is
-/// already over the line limit.
+/// running on its own, and two fewer lines in the `compile_pass_tests_*` halves,
+/// which are already over the line limit.
 #[test]
 fn agent_authority_compile_pass_tests() {
     let t = trybuild::TestCases::new();
@@ -388,8 +388,16 @@ fn cache_coherence_compile_fail_tests() {
     t.compile_fail("tests/compile-fail/repository_acknowledge_stale_blank_reason.rs");
 }
 
+// Split into `_a` / `_b` halves so CI can run them as two parallel trybuild
+// shards (see the `trybuild` job in .github/workflows/ci.yml). Each half owns a
+// disjoint slice of the SAME fixture list — nothing is gated on the split, so a
+// new fixture may be appended to either half. `compile_pass` cases are the
+// expensive ones: unlike a `compile_fail` case, which stops at the first
+// diagnostic, each one compiles AND links a whole crate against autumn-web —
+// which is why they were 25 of the 37 minutes trybuild spent on Windows in the
+// run that motivated the split.
 #[test]
-fn compile_pass_tests() {
+fn compile_pass_tests_a() {
     let t = trybuild::TestCases::new();
 
     // Build-time cache coherence (#1716): a declared dependency set, an
@@ -494,6 +502,12 @@ fn compile_pass_tests() {
     // uses `serialize_as`, as every `#[encrypted]` field does (#1340).
     #[cfg(feature = "db")]
     t.pass("tests/compile-pass/repository_encrypted_hooks.rs");
+}
+
+// The second half of the `compile_pass` fixture list; see `compile_pass_tests_a`.
+#[test]
+fn compile_pass_tests_b() {
+    let t = trybuild::TestCases::new();
 
     // Sharding extractors + repository with_pool over a shard (requires db feature)
     #[cfg(feature = "db")]


### PR DESCRIPTION
## Why

The `test` job was CI's critical path. It was one job per OS that ran, in sequence: the whole workspace suite, then eight feature-flipped re-builds, then the Docker sweep. On the [2026-08-26 trunk run](https://github.com/autumn-foundation/autumn/actions/runs/32972045877) it was **128 minutes on Windows** and 92 on macOS, inside a 2h27m workflow.

Rather than guess where the time went, I pulled that run's job logs and measured it:

|                          | ubuntu | macos | windows |
|---|---|---|---|
| compile (`cargo test -W`) | 11.6m | 29.1m | 27.0m |
| run: `integration_tests`  | 14.4m | 17.4m | **46.8m** |
| …of which trybuild        | 10.3m | 12.0m | **37.1m** |
| run: 142 other binaries   | 1.9m  | 5.0m  | 4.7m |
| gated feature re-builds   | 25.0m | 38.3m | 44.0m |

Two findings drive the split:

1. **`compile_fail::*` (trybuild) was 71–79% of the consolidated `integration_tests` binary's run time — and it was the tail.** The binary finished 0.2s after trybuild did, on every OS. Each case shells out a nested `cargo` build that trybuild serialises behind its project-dir lock, and libtest cannot split a single `#[test]`. It does not get faster with more threads; only with more runners.
2. **The eight gated feature lanes are independent re-builds** of autumn-web under disjoint feature sets, run back to back for ~44 minutes on Windows despite sharing nothing but the source tree.

## What changed

`test` becomes four job families that run side by side, behind one aggregate check:

| Job | Runs |
|---|---|
| `test` (× 3 OS) | `cargo test --workspace -- --skip compile_fail::` |
| `trybuild` (× 3 OS × 4 shards) | `compile_fail::` only — `fail` / `pass_a` / `pass_b` / `rest` |
| `test-features` (× 8 lanes) | one job per non-default feature set |
| `test-docker` (Linux) | the `#[ignore]`d testcontainer sweep |
| `test-gate` | aggregate — fails if any shard did not succeed |

`compile_pass_tests` is split into `compile_pass_tests_a` / `_b` — a disjoint split of the same fixture list, **25 + 31 = the original 56**, nothing added or removed.

Every shard still runs `cargo test --workspace`, deliberately: the trybuild fixture list is `#[cfg(feature = ...)]`-gated, so narrowing a shard to `-p autumn-web --test integration_tests` would quietly compile fewer fixtures in and still report green. Each shard asserts a non-zero pass count, because `cargo test` exits 0 when a filter matches nothing.

## Measured effect

From [run 8383](https://github.com/autumn-foundation/autumn/actions/runs/33945686803) (all shards green; the three `Test` legs are red only from the unrelated base breakage below):

| | ubuntu | windows | macos |
|---|---|---|---|
| slowest feature lane | 11.7m | 20.8m | 33.9m |
| *was, sequential in one job* | 25.0m | 44.0m | 38.3m |
| slowest trybuild shard | 29.7m | **57.5m** | 45.7m |
| Docker sweep | 32.8m | — | — |

**End to end: ~87m, against the 2h27m baseline — about 41% faster.**

An earlier revision of this description predicted ~1h10m / ~52%. That was wrong, and the error is worth naming: it assumed the shards would run against a warm `rust-cache`, which they do not on a first run. **These numbers are entirely cold-cache** — every shard paid a full workspace compile. `shared-key: workspace-test` (added in c0a771e) lets the shards restore the entry the `test` job writes, but a writer only saves at the *end* of its job, so the shards in this run were still cold. The warm-cache figure is not yet measured; expect the trybuild shards, which are the pole and are compile-bound rather than trybuild-bound, to be where it shows up.

Two follow-ups if the warm-cache run does not close the gap:
- run `test-features`' five cross-platform lanes on Linux only — none is platform-specific, and the ones that are already carry Linux-only guards;
- replace the per-shard compile with build-once/run-many (`cargo nextest archive` + `--partition`).

Also out of scope but on the critical path: `Lint` is 28m of sequential clippy passes gating every test job, and it splits the same way.

## ⚠️ Required repo-config follow-up

**Branch protection must be repointed** from the per-OS `Test (…)` checks to **`Test suite`** (the `test-gate` job) — the one check name that stays stable as shards are added or removed. The old names no longer exist. I cannot change branch protection.

## Not this PR: `trunk-dev` is broken

The three `Test` legs fail on four `autumn-macros` tests with `route macros can only be applied to functions`. This PR does not touch `autumn-macros`. Bisected: `02177ca` (#2484, which added the tests) is green; `0955f0f` (#2488, the next commit) is red; `trunk-dev`'s tip is red. #2488 made the guard macros emit a gate type *alongside* the handler, and `parse_async_handler` parses a single `ItemFn`. Full diagnosis and a proposed patch are in [this comment](https://github.com/autumn-foundation/autumn/pull/2519#issuecomment-5548813644).

It blocks more than merge: `cargo test --workspace` stops at the first failing binary, and `autumn_macros` runs at position **14 of 154** — before `integration_tests` — so every `Test` leg aborts early and the full-suite timing cannot be measured until it is fixed.

## Verification

- `--list` confirms the four shard filters partition `compile_fail::`'s ten tests **exactly** — 1 / 1 / 1 / 7 — and `--skip compile_fail::` removes exactly those ten of 1883, so `test` and `trybuild` are jointly exhaustive by construction.
- Ran `compile_pass_tests_a`, `compile_pass_tests_b` and the `rest` shard locally through `cargo test`: all green.
- All 12 trybuild shards and all 18 feature-lane jobs green in CI.
- `actionlint` clean across every workflow (it caught an invalid-expression bug that a YAML parse had passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ja9cLSLqsuaR2xrNmViQUr