### PR TITLE
🛡 Warden: fold the ambient tenant into every #[cached] key (cross-tenant read, #[cached] × tenant_scoped)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3215,6 +3215,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   function that quietly delegated to its borrowed twin would fail even though
   its output is correct.
 
+### Fixed
+
+- **macros: `#[throttle]`/`#[secured]`/`#[step_up]` above the route macro no
+  longer fail to compile, or silently drop the OpenAPI response schema, once
+  stacked (#1668 regression):** #1668 moved these three guards' runtime
+  checks out of the handler body into each guard's own handler-unique
+  `FromRequestParts` gate — `struct` + `impl`, emitted as a sibling item
+  ahead of the (still single) handler function. Every route macro's own
+  `item` parser (`parse::parse_async_handler`, plus the three guard macros'
+  own parsers, needed when one guard expands above another) only ever
+  accepted a lone `ItemFn`, so a guard macro receiving that two-item output
+  as `item` — any of `#[throttle]`/`#[secured]`/`#[step_up]`/`#[route]`
+  written *above* another guard already using the #1668 gate shape — hit a
+  spurious `route macros can only be applied to functions` compile error.
+  `parse::parse_async_handler_with_preamble` now accepts zero or more
+  leading item definitions ahead of the trailing function, returning them
+  separately so the route/guard macro re-emits that preamble (the gate type
+  the function's new first parameter names) verbatim instead of choking on
+  it.
+
+  Fixing the parse gap surfaced a second, previously-masked bug: with
+  parsing no longer failing first, `#[throttle]`/`#[step_up]` above
+  `#[route]` still resolved to no OpenAPI response schema, because
+  `api_doc::infer_response_body`'s `__autumn_inner`-binding recovery (#1677)
+  only trusts that binding when one of `RESPONSE_REWRITING_GUARD_MARKERS`'s
+  marker consts sits earlier in the *same* handler-body block — and #1668
+  moved `#[throttle]`'s/`#[step_up]`'s marker consts into their gate's
+  `impl` block, out of the body, while `#[secured]`'s marker consts stayed
+  in-body for exactly this reason. Both guards now also leave a dead-code
+  copy of their marker const in the handler body (mirroring `#[secured]`'s
+  existing `role_scope_consts` pattern), restoring the invariant
+  `infer_response_body` relies on — including through stacked guards, where
+  only the innermost binding carries the handler's real return type.
+
+  Regression-proven at both the macro-expansion level (`route.rs`'s
+  existing `route_macro_infers_response_schema_when_throttle_expands_first`
+  / `..._when_step_up_expands_first` / `..._under_stacked_guards_above_route`
+  tests, which predate this fix but never previously reached the code path
+  they exercise) and end to end: `cargo test -p autumn-macros --lib` (1073
+  passed), `cargo fmt --all -- --check`, `cargo clippy -p autumn-macros
+  --all-targets -- -D warnings` all clean.
+
 ## [0.7.0] - 2026-08-23
 
 For a narrative tour of this release, see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1601,6 +1601,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   internal-only receiver during development) will see those deliveries start
   failing after upgrade — this is the intended effect of closing the gap. See
   `docs/security/2026-09-03-webhook-ssrf/`.
+- **`#[cached]`'s generated cache key now folds in the ambient resolved
+  tenant:** the key was built exclusively from the function's own explicit
+  arguments (every parameter by default, or exactly the parameters named in
+  `key(...)`) and never consulted the `CURRENT_TENANT` task-local a
+  `tenant_scoped` repository read filters by. An app that turned on Autumn's
+  multi-tenancy (`[tenancy] enabled = true`) and cached a `tenant_scoped`
+  read keyed on any parameter *other* than the tenant itself — a page, an
+  export format, a filter, anything but the literal `tenant_id` the SaaS
+  starter's own `cached_project_count` goes out of its way to thread through
+  `key(tenant_id)` — shared one cache slot across every tenant that called it
+  with the same non-tenant arguments: tenant B received **tenant A's cached
+  response** for the remainder of the entry's TTL. Nothing in the macro, the
+  build-time cache-coherence gate (`autumn cache audit`), or `autumn routes
+  audit` detected or prevented the omission, and Autumn's own tenancy idiom
+  never requires threading `tenant_id` through a function signature for any
+  *other* tenant-scoped operation (`tenant_scoped` finders resolve it from
+  `CURRENT_TENANT` automatically) — so the omission was an easy, natural
+  mistake, not a documented misuse. The generated wrapper now reads
+  `CURRENT_TENANT` (when tenancy is enabled and a tenant has been resolved)
+  and folds it into the key unconditionally, in addition to whatever `key(...)`
+  already names. Apps without tenancy enabled, or calling a `#[cached]`
+  function outside a request (a background job, a scheduled sweep), compute
+  the same key as before — `CURRENT_TENANT` resolves to `None` in both cases.
+  **Compatibility note:** a `#[cached]` function that intentionally serves one
+  shared, cross-tenant value (a genuinely global computation, not a
+  `tenant_scoped` read) now partitions its cache per resolved tenant too when
+  called from within a tenant's request — a harmless drop in hit rate, not a
+  correctness change, since the computed value does not vary by tenant. See
+  `docs/security/2026-09-05-cached-tenant-key/`.
 
 ### Fixed
 

--- a/autumn-macros/src/cached.rs
+++ b/autumn-macros/src/cached.rs
@@ -608,7 +608,24 @@ fn generate_cache_body(
             __autumn_global
                 .as_deref()
                 .unwrap_or(&**__autumn_moka as &dyn ::autumn_web::cache::Cache);
-        let __autumn_key = ::autumn_web::cache::make_cache_key(#id_expr, #key_args);
+        // Fold the ambient resolved tenant into every cache key, unconditionally.
+        // `key(...)` (or the full parameter list, without it) only ever sees this
+        // function's own explicit arguments — never the request's `CURRENT_TENANT`
+        // task-local a `tenant_scoped` repository read filters by — so a cached
+        // function keyed on some other legitimate parameter (a page, a format, a
+        // filter — anything but the tenant) would otherwise share one cache slot
+        // across every tenant that calls it with the same arguments. `None` outside
+        // a tenancy-enabled request (or with tenancy disabled entirely) leaves
+        // single-tenant apps' keys unchanged.
+        let __autumn_tenant_key_component: ::core::option::Option<::std::string::String> =
+            ::autumn_web::tenancy::CURRENT_TENANT
+                .try_with(::std::clone::Clone::clone)
+                .ok()
+                .flatten();
+        let __autumn_key = ::autumn_web::cache::make_cache_key(
+            #id_expr,
+            &(__autumn_tenant_key_component, #key_args),
+        );
     };
 
     if attrs.result {

--- a/autumn-macros/src/parse.rs
+++ b/autumn-macros/src/parse.rs
@@ -322,10 +322,51 @@ fn validate_path(path: &LitStr) -> Result<(), TokenStream> {
 /// Returns `Ok(func)` if valid, or a compile error `TokenStream` if not.
 /// Validates: is a function, is async.
 pub fn parse_async_handler(item: TokenStream) -> Result<ItemFn, TokenStream> {
-    let input_fn: ItemFn = syn::parse2(item.clone()).map_err(|_| {
+    let (preamble, input_fn) = parse_async_handler_with_preamble(item)?;
+    if !preamble.is_empty() {
+        return Err(syn::Error::new_spanned(
+            preamble,
+            "route macros can only be applied to functions",
+        )
+        .to_compile_error());
+    }
+    Ok(input_fn)
+}
+
+/// Parse and validate an async handler function from macro input, tolerating
+/// zero or more item definitions ahead of it.
+///
+/// A guard macro that expands before the route macro (e.g.
+/// `#[throttle]`/`#[secured]`/`#[step_up]`, since #1668's pre-body
+/// `FromRequestParts` gate refactor) emits its handler-unique gate `struct`
+/// and its `impl FromRequestParts` block ahead of the modified handler
+/// function, rather than a single function. Route macros need those leading
+/// items re-emitted verbatim (the handler's new first parameter names the
+/// gate type they define), so this returns them separately from the trailing
+/// function instead of failing to parse.
+///
+/// Returns `Ok((preamble, func))` if the input ends in a function — `preamble`
+/// is the empty `TokenStream` when there is no guard gate ahead of it — or a
+/// compile error `TokenStream` if not. Validates: ends in a function, that
+/// function is async.
+pub fn parse_async_handler_with_preamble(
+    item: TokenStream,
+) -> Result<(TokenStream, ItemFn), TokenStream> {
+    let file: syn::File = syn::parse2(item.clone()).map_err(|_| {
         syn::Error::new_spanned(item, "route macros can only be applied to functions")
             .to_compile_error()
     })?;
+
+    let mut items = file.items;
+    let last = items.pop();
+    let Some(syn::Item::Fn(input_fn)) = last else {
+        let trailing = items.into_iter().chain(last);
+        return Err(syn::Error::new_spanned(
+            quote! { #(#trailing)* },
+            "route macros can only be applied to functions",
+        )
+        .to_compile_error());
+    };
 
     if input_fn.sig.asyncness.is_none() {
         return Err(syn::Error::new_spanned(
@@ -335,7 +376,8 @@ pub fn parse_async_handler(item: TokenStream) -> Result<ItemFn, TokenStream> {
         .to_compile_error());
     }
 
-    Ok(input_fn)
+    let preamble = quote! { #(#items)* };
+    Ok((preamble, input_fn))
 }
 
 /// Extract `#[intercept(LayerType)]` attributes from a function's attribute

--- a/autumn-macros/src/route.rs
+++ b/autumn-macros/src/route.rs
@@ -37,8 +37,8 @@ pub fn route_macro(
     };
     let path = route_args.path.clone();
 
-    let mut input_fn = match parse::parse_async_handler(item) {
-        Ok(f) => f,
+    let (preamble, mut input_fn) = match parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
         Err(err) => return err,
     };
 
@@ -256,6 +256,13 @@ pub fn route_macro(
     };
 
     quote! {
+        // A guard macro that already expanded above this route macro (#1668:
+        // #[throttle]/#[secured]/#[step_up]) leaves its handler-unique gate
+        // `struct` + `impl FromRequestParts` here, ahead of the function —
+        // the function's new first parameter names that gate type, so it
+        // must be re-emitted verbatim for the gate type to exist.
+        #preamble
+
         // ECHO-001: We want to apply #[axum::debug_handler] but without forcing the user
         // to import axum manually. However, the path resolution in Axum macros makes this impossible
         // natively. Custom compile errors handle the type checks.

--- a/autumn-macros/src/secured.rs
+++ b/autumn-macros/src/secured.rs
@@ -24,7 +24,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ExprLit, ItemFn, Lit, LitStr, Meta, Token, parse_quote};
+use syn::{Expr, ExprLit, Lit, LitStr, Meta, Token, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -118,18 +118,15 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[throttle]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[secured] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     // The session/role check is emitted for the classic forms (`#[secured]`,
     // `#[secured("admin")]`) and whenever a role is required. It is OMITTED for
@@ -312,6 +309,7 @@ pub fn secured_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/step_up.rs
+++ b/autumn-macros/src/step_up.rs
@@ -17,7 +17,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{ItemFn, LitStr, parse_quote};
+use syn::{LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -196,17 +196,15 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(v) => v,
         Err(err) => return err.to_compile_error(),
     };
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[step_up]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[step_up] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     let max_age_tokens = max_age_opt.map_or_else(
         || quote! { ::core::option::Option::None },
@@ -329,13 +327,29 @@ pub fn step_up_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
+    // A dead-code marker mirroring the real `__AUTUMN_STEP_UP_MAX_AGE` const
+    // the gate carries (#1668 moved the runtime check itself into the gate's
+    // own `impl` block, out of the handler body). `api_doc::infer_response_body`
+    // recovers a guard-rewritten handler's real return type from the
+    // `__autumn_inner` binding below, but only accepts that binding when one
+    // of `RESPONSE_REWRITING_GUARD_MARKERS` is present earlier in the *same*
+    // block — so `#[step_up]` needs its own marker in-body too, exactly like
+    // `#[secured]`'s role/scope consts, or a route stacking `#[step_up]`
+    // above `#[route]` silently loses its OpenAPI response schema (#1677).
+    let body_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_STEP_UP_MAX_AGE: ::core::option::Option<u64> = #max_age_tokens;
+    };
+
     input_fn.block = syn::parse_quote! {
         {
+            #body_marker
             #original_response
         }
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }

--- a/autumn-macros/src/throttle.rs
+++ b/autumn-macros/src/throttle.rs
@@ -21,7 +21,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::parse::Parser as _;
-use syn::{Expr, ItemFn, Lit, LitInt, LitStr, parse_quote};
+use syn::{Expr, Lit, LitInt, LitStr, parse_quote};
 
 use crate::idempotency_guard::should_own_replay;
 
@@ -251,18 +251,15 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(err) => return err.to_compile_error(),
     };
 
-    let mut input_fn: ItemFn = match syn::parse2(item) {
-        Ok(f) => f,
-        Err(err) => return err.to_compile_error(),
+    // `parse_async_handler_with_preamble` also tolerates zero or more item
+    // definitions ahead of the function — the gate `struct` + `impl
+    // FromRequestParts` a guard macro that already expanded above this one
+    // (e.g. `#[secured]` above `#[throttle]`) leaves behind — and already
+    // validates the trailing function is async.
+    let (preamble, mut input_fn) = match crate::parse::parse_async_handler_with_preamble(item) {
+        Ok(v) => v,
+        Err(err) => return err,
     };
-
-    if input_fn.sig.asyncness.is_none() {
-        return syn::Error::new_spanned(
-            input_fn.sig.fn_token,
-            "#[throttle] can only be applied to async functions",
-        )
-        .to_compile_error();
-    }
 
     let fn_name = input_fn.sig.ident.clone();
     let fn_name_str = fn_name.to_string();
@@ -437,13 +434,29 @@ pub fn throttle_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
     input_fn.sig.output = parse_quote! {
         -> ::autumn_web::reexports::axum::response::Response
     };
+    // A dead-code marker mirroring the real `__AUTUMN_THROTTLE_ROUTE_ID` const
+    // the gate carries (#1668 moved the runtime check itself into the gate's
+    // own `impl` block, out of the handler body). `api_doc::infer_response_body`
+    // recovers a guard-rewritten handler's real return type from the
+    // `__autumn_inner` binding below, but only accepts that binding when one
+    // of `RESPONSE_REWRITING_GUARD_MARKERS` is present earlier in the *same*
+    // block — so `#[throttle]` needs its own marker in-body too, exactly like
+    // `#[secured]`'s `role_scope_consts`, or a route stacking `#[throttle]`
+    // above `#[route]` silently loses its OpenAPI response schema (#1677).
+    let body_marker = quote! {
+        #[allow(dead_code)]
+        const __AUTUMN_THROTTLE_ROUTE_ID: &str = #fn_name_str;
+    };
+
     input_fn.block = syn::parse_quote! {
         {
+            #body_marker
             #original_response
         }
     };
 
     quote! {
+        #preamble
         #gate_item
         #input_fn
     }

--- a/autumn/tests/cached_global_backend.rs
+++ b/autumn/tests/cached_global_backend.rs
@@ -91,7 +91,14 @@ fn cached_fn_reads_from_global_on_hit() {
     clear_global_cache();
 
     let global_moka = Arc::new(MokaCache::new(100, None));
-    let key = make_cache_key(concat!(module_path!(), "::double_a"), &(42_i32,));
+    // The generated key now folds in the ambient resolved tenant ahead of the
+    // named key parameters (Warden 2026-09-05, docs/security/2026-09-05-cached-tenant-key/):
+    // `None` here since these plain functions run outside any tenancy-resolved
+    // request context.
+    let key = make_cache_key(
+        concat!(module_path!(), "::double_a"),
+        &(Option::<String>::None, &(42_i32,)),
+    );
     // Store 999 under the key that double_a(42) would normally compute as 84.
     autumn_web::cache::insert(global_moka.as_ref(), &key, 999_i32);
     set_global_cache(global_moka);
@@ -115,8 +122,12 @@ fn cached_fn_writes_to_global_on_miss() {
     let (counting, inserts) = CountingCache::new();
     set_global_cache(Arc::new(counting.clone()) as Arc<dyn Cache>);
 
-    // Ensure the key is absent from the global before calling
-    let key = make_cache_key(concat!(module_path!(), "::double_b"), &(5_i32,));
+    // Ensure the key is absent from the global before calling. See the
+    // comment in `cached_fn_reads_from_global_on_hit` for why `None` leads.
+    let key = make_cache_key(
+        concat!(module_path!(), "::double_b"),
+        &(Option::<String>::None, &(5_i32,)),
+    );
     counting.inner.invalidate(&key);
 
     let result = double_b(5);

--- a/autumn/tests/integration/cached_tenant_scope.rs
+++ b/autumn/tests/integration/cached_tenant_scope.rs
@@ -1,7 +1,7 @@
 //! Cross-tenant `#[cached]` read (Warden 2026-09-05).
 //!
 //! Composes two documented framework features exactly as the framework's own
-//! SaaS starter does (`examples/saas/src/repositories.rs`): `[tenancy]
+//! `SaaS` starter does (`examples/saas/src/repositories.rs`): `[tenancy]
 //! enabled = true` (`docs/guide/tenant-cells.md`) and `#[cached]` memoizing a
 //! read over a `tenant_scoped` `#[repository]` (`docs/guide/cache-coherence.md`).
 //!
@@ -11,7 +11,7 @@
 //! `CURRENT_TENANT` task-local that a `tenant_scoped` repository read filters
 //! by — so a cached function whose only *other* varying parameter is not the
 //! tenant (a `page`, a `format`, a filter — anything that is not the literal
-//! `tenant_id` the SaaS starter's own `cached_project_count` goes out of its
+//! `tenant_id` the `SaaS` starter's own `cached_project_count` goes out of its
 //! way to thread through `key(tenant_id)`) shares one cache slot across every
 //! tenant that ever calls it with the same non-tenant arguments.
 //!
@@ -61,7 +61,7 @@ pub struct CtsWidget {
 #[autumn_web::repository(CtsWidget, table = "cts_widgets", tenant_scoped)]
 pub trait CtsWidgetRepository {}
 
-/// The buggy-but-natural sibling of the SaaS starter's `cached_project_count`:
+/// The buggy-but-natural sibling of the `SaaS` starter's `cached_project_count`:
 /// keyed on a real, legitimate, non-tenant parameter (`format`) instead of
 /// `tenant_id`. `repo` is correctly kept out of the key (it is a per-request
 /// handle, not part of the value's identity — exactly per the starter's own

--- a/autumn/tests/integration/cached_tenant_scope.rs
+++ b/autumn/tests/integration/cached_tenant_scope.rs
@@ -1,0 +1,187 @@
+//! Cross-tenant `#[cached]` read (Warden 2026-09-05).
+//!
+//! Composes two documented framework features exactly as the framework's own
+//! SaaS starter does (`examples/saas/src/repositories.rs`): `[tenancy]
+//! enabled = true` (`docs/guide/tenant-cells.md`) and `#[cached]` memoizing a
+//! read over a `tenant_scoped` `#[repository]` (`docs/guide/cache-coherence.md`).
+//!
+//! `#[cached]`'s generated cache key is built exclusively from the function's
+//! own *explicit* parameters (every parameter by default, or exactly the
+//! parameters named in `key(...)`). It never consults the ambient
+//! `CURRENT_TENANT` task-local that a `tenant_scoped` repository read filters
+//! by — so a cached function whose only *other* varying parameter is not the
+//! tenant (a `page`, a `format`, a filter — anything that is not the literal
+//! `tenant_id` the SaaS starter's own `cached_project_count` goes out of its
+//! way to thread through `key(tenant_id)`) shares one cache slot across every
+//! tenant that ever calls it with the same non-tenant arguments.
+//!
+//! The framework's own example shows the *correct* pattern (thread `tenant_id`
+//! explicitly and name it in `key(...)`) but nothing in the macro, the
+//! build-time cache-coherence gate (`autumn cache audit`), or `autumn routes
+//! audit` detects or prevents its omission — and Autumn's own tenancy idiom
+//! never requires threading `tenant_id` through a function signature for
+//! every *other* tenant-scoped operation (`tenant_scoped` repository finders
+//! resolve it from `CURRENT_TENANT` automatically). A developer who caches a
+//! `tenant_scoped` read keyed on some other legitimate parameter (rather than
+//! the tenant) has done nothing the documentation told them not to do.
+
+#![cfg(all(feature = "db", feature = "cache-moka"))]
+
+use autumn_web::config::AutumnConfig;
+use autumn_web::test::TestApp;
+use autumn_web::{AutumnResult, get, public, routes};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+mod schema {
+    autumn_web::reexports::diesel::table! {
+        cts_widgets (id) {
+            id -> Int8,
+            tenant_id -> Text,
+            label -> Text,
+        }
+    }
+}
+use schema::cts_widgets;
+
+#[autumn_web::model]
+pub struct CtsWidget {
+    #[id]
+    pub id: i64,
+    #[default]
+    pub tenant_id: String,
+    pub label: String,
+}
+
+/// Mirrors `examples/saas/src/repositories.rs`'s `ProjectRepository`: every
+/// read is filtered by the ambient tenant, enforced at the SQL level.
+#[autumn_web::repository(CtsWidget, table = "cts_widgets", tenant_scoped)]
+pub trait CtsWidgetRepository {}
+
+/// The buggy-but-natural sibling of the SaaS starter's `cached_project_count`:
+/// keyed on a real, legitimate, non-tenant parameter (`format`) instead of
+/// `tenant_id`. `repo` is correctly kept out of the key (it is a per-request
+/// handle, not part of the value's identity — exactly per the starter's own
+/// `key(tenant_id)` comment) but nothing forces `tenant_id` to be named too.
+#[autumn_web::cached(ttl = "60s", key(format), result)]
+pub async fn cached_widget_labels(
+    format: &'static str,
+    repo: &PgCtsWidgetRepository,
+) -> AutumnResult<String> {
+    let widgets = repo.find_all().await?;
+    let labels = widgets
+        .into_iter()
+        .map(|w| w.label)
+        .collect::<Vec<_>>()
+        .join(",");
+    Ok(format!("{format}:{labels}"))
+}
+
+/// `tenant_scoped` resolves the tenant from `CURRENT_TENANT` automatically —
+/// nothing here ever names a tenant explicitly, exactly like
+/// `examples/saas/src/routes/dashboard.rs`'s `dashboard` handler.
+#[get("/widgets/summary")]
+#[public]
+async fn widgets_summary(repo: PgCtsWidgetRepository) -> AutumnResult<String> {
+    cached_widget_labels("csv", &repo).await
+}
+
+fn tenancy_config() -> AutumnConfig {
+    let mut config = AutumnConfig::default();
+    config.tenancy.enabled = true;
+    "header".clone_into(&mut config.tenancy.source);
+    "x-tenant-id".clone_into(&mut config.tenancy.header_name);
+    config
+}
+
+async fn setup_pool() -> (
+    Pool<AsyncPgConnection>,
+    testcontainers::ContainerAsync<Postgres>,
+) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start postgres container");
+
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(&url);
+    let pool = Pool::builder(manager).max_size(5).build().expect("pool");
+
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "CREATE TABLE cts_widgets (\
+           id BIGSERIAL PRIMARY KEY, \
+           tenant_id TEXT NOT NULL, \
+           label TEXT NOT NULL)",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("DDL failed");
+    drop(conn);
+
+    (pool, container)
+}
+
+/// Issue: tenant B receives tenant A's cached `#[cached]` result because the
+/// generated cache key is `hash(format)` alone — no tenant component.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn cached_tenant_scoped_read_leaks_across_tenants() {
+    let (pool, _container) = setup_pool().await;
+    let mut conn = pool.get().await.expect("conn");
+    diesel::sql_query(
+        "INSERT INTO cts_widgets (tenant_id, label) VALUES ('tenant-a', 'tenant-a-sentinel')",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("seed tenant A");
+    diesel::sql_query(
+        "INSERT INTO cts_widgets (tenant_id, label) VALUES ('tenant-b', 'tenant-b-sentinel')",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("seed tenant B");
+    drop(conn);
+
+    let app = TestApp::new()
+        .config(tenancy_config())
+        .with_db(pool)
+        .routes(routes![widgets_summary])
+        .build();
+
+    let first = app
+        .get("/widgets/summary")
+        .header("x-tenant-id", "tenant-a")
+        .send()
+        .await;
+    first.assert_ok();
+    assert!(
+        first.text().contains("tenant-a-sentinel"),
+        "tenant A's own request must see its own sentinel: {:?}",
+        first.text()
+    );
+
+    let second = app
+        .get("/widgets/summary")
+        .header("x-tenant-id", "tenant-b")
+        .send()
+        .await;
+    second.assert_ok();
+    assert!(
+        !second.text().contains("tenant-a-sentinel"),
+        "tenant B received tenant A's cached #[cached] response body: {:?} \
+         (the cache key never carried the resolved tenant)",
+        second.text()
+    );
+    assert!(
+        second.text().contains("tenant-b-sentinel"),
+        "tenant B must see its own data once isolated: {:?}",
+        second.text()
+    );
+}

--- a/autumn/tests/integration/mod.rs
+++ b/autumn/tests/integration/mod.rs
@@ -28,6 +28,8 @@ mod broadcast_recorder;
 mod cache_coherence;
 #[cfg(feature = "cache-moka")]
 mod cache_stampede;
+#[cfg(all(feature = "db", feature = "cache-moka"))]
+mod cached_tenant_scope;
 #[cfg(feature = "ws")]
 mod chaos_channels;
 #[cfg(feature = "ws")]

--- a/docs/security/2026-09-05-cached-tenant-key/README.md
+++ b/docs/security/2026-09-05-cached-tenant-key/README.md
@@ -1,10 +1,11 @@
-# Cross-tenant `#[cached]` read via a tenant-blind cache key (2026-09-05)
+# Cross-tenant `#[cached]` read (2026-09-05)
 
-**Class:** cross-tenant read through an authenticated surface
-**Surface:** `autumn-macros::cached` — `#[cached]`'s generated cache-key
-construction
-**Entry point:** any HTTP route (or any code path) that calls a `#[cached]`
-function memoizing a `tenant_scoped` `#[repository]` read
+**Class:** cross-tenant read through an authenticated surface, via a
+framework cache key missing the tenant
+**Surface:** `autumn_web::cached` (`autumn-macros::cached::cached_macro`) ×
+`#[repository(..., tenant_scoped)]`
+**Entry point:** any HTTP route (or other caller) invoking a `#[cached]`
+function that memoizes a `tenant_scoped` repository read
 **Affected:** `autumn-web` 0.7.0 and every earlier release that shipped
 `#[cached]`
 **Status:** fixed — `autumn-macros/src/cached.rs`
@@ -12,163 +13,141 @@ function memoizing a `tenant_scoped` `#[repository]` read
 ## 🕵️ Threat model
 
 > Against an app that follows Autumn's own documented patterns — turns on
-> multi-tenancy (`[tenancy] enabled = true`, per `docs/guide/tenant-cells.md`)
-> and memoizes a `tenant_scoped` repository read with `#[cached]` (per
-> `docs/guide/cache-coherence.md`, exactly as the framework's own SaaS starter
-> does in `examples/saas/src/repositories.rs`) — an attacker who is an
+> multi-tenancy (`[tenancy] enabled = true`) and memoizes a `tenant_scoped`
+> repository read with `#[cached]`, exactly as the framework's own SaaS
+> starter does in `examples/saas/src/repositories.rs` — an attacker who is an
 > ordinary authenticated principal of tenant B can obtain **tenant A's cached
 > response** from any such cached read, for the remainder of the entry's TTL,
 > simply by calling the same route/function with the same *non-tenant*
-> arguments tenant A used. The app author did nothing the documentation told
-> them not to do: the SaaS starter's own `cached_project_count` is the
-> *correct* pattern (thread `tenant_id` explicitly and name it in
-> `key(tenant_id)`), but nothing in the macro, the build-time cache-coherence
-> gate (`autumn cache audit`), or `autumn routes audit` detects or prevents
-> its omission — and every *other* `tenant_scoped` operation in Autumn
-> resolves the tenant from the ambient `CURRENT_TENANT` task-local
-> automatically, with no explicit parameter required. A developer who caches
-> a `tenant_scoped` read keyed on some other legitimate, real parameter
-> (a page number, an export format, a filter) instead of the tenant has
-> followed the framework's own ambient-scoping idiom everywhere else — and
-> been bitten by the one place it silently doesn't apply.
+> arguments tenant A used; the app author did nothing the documentation told
+> them not to do.
+
+The SaaS starter's own `cached_project_count` is the framework's *documented
+correct* pattern: thread `tenant_id` explicitly through the function
+signature and name it in `key(tenant_id)`. But nothing enforces that pattern.
+Every *other* `tenant_scoped` operation in Autumn resolves the tenant from
+the ambient `CURRENT_TENANT` task-local automatically, with **no** explicit
+parameter required — `tenant_scoped` finders, `save()`, preload, retention
+sweeps, all of it. `#[cached]` is the one place that idiom silently doesn't
+apply: its generated cache key is built purely from the function's own
+explicit arguments. A developer who caches a `tenant_scoped` read keyed on
+some other real, legitimate parameter (a page number, an export format, a
+filter) instead of the tenant has followed the framework's ambient-scoping
+idiom everywhere else and been bitten by the one place it silently doesn't
+hold — not "held it wrong," a framework default that is unsafe by
+composition.
+
+## 🧪 Reproduction
+
+Test: `autumn/tests/integration/cached_tenant_scope.rs::cached_tenant_scoped_read_leaks_across_tenants`
+
+Seeds two tenants' sentinel rows (`tenant-a-sentinel`, `tenant-b-sentinel`)
+in a `tenant_scoped` `#[repository]` model, defines `cached_widget_labels` —
+the buggy-but-natural sibling of the SaaS starter's `cached_project_count`,
+keyed on a real non-tenant parameter (`format`) instead of the tenant — and
+drives it through a real HTTP route (`GET /widgets/summary`) via `TestApp` +
+header-based tenancy, mirroring the convention already established in
+`docs/security/2026-09-02-idempotency-tenant-scope/`.
+
+Committed as `#[ignore = "requires Docker (testcontainers)"]` per
+`CLAUDE.md`'s Integration Test Layout Guidelines — CI's Docker sweep picks it
+up automatically, no workflow edit needed. This sandbox had no Docker daemon,
+so the red/green runs below were captured with an identical scratch harness
+(`autumn/tests/warden_scratch_cached_tenant.rs`, not committed) pointed at a
+natively-installed PostgreSQL 16 service instead of a testcontainer — only
+the pool's connection source differs, and the fix commit
+(`autumn-macros/src/cached.rs`) was reverted via `git stash` and restored
+against the *same* running Postgres, so the two runs differ by exactly that
+one file.
+
+See `trunk-failure.txt` (fix reverted, FAILED) and `after.txt` (fix
+restored, ok — plus the pre-existing `#[cached]` macro unit tests and the
+cache-coherence integration suite, both unaffected).
 
 ## 🔎 Root cause
 
-`autumn-macros/src/cached.rs`'s `generate_cache_body` builds the runtime
-key as:
+`autumn-macros/src/cached.rs::generate_cache_body` built the key as:
 
 ```rust
 let __autumn_key = ::autumn_web::cache::make_cache_key(#id_expr, #key_args);
 ```
 
-`#key_args` (from `key_tuple`) is built exclusively from the function's own
-*explicit* parameters — every parameter by default, or exactly the
-parameters named in `key(...)` when present (`autumn-macros/src/cached.rs`
-`key_tuple`, ~line 489). It never reads `autumn_web::tenancy::CURRENT_TENANT`
-— the task-local a `tenant_scoped` repository read filters by
-(`autumn-macros/src/repository.rs` ~line 1913: `CURRENT_TENANT.try_with(...)`
-inside every `tenant_scoped` finder). The build-time cache-coherence gate
-(`autumn-cli/src/cache_audit.rs`) proves only *staleness* edges (a cached
-read's declared/derived model dependencies vs. a repository's
-`invalidates(...)` clause) — it has no notion of tenant-key correctness at
-all, so a `#[cached(reads(TenantScopedModel))]` function with no
-tenant-identifying key parameter compiles, passes `autumn cache audit`, and
-runs.
+where `#key_args` (from `key_tuple`, ~line 489) is exclusively the
+function's own explicit parameters — every parameter by default, or exactly
+the parameters named in `key(...)`. It never read
+`autumn_web::tenancy::CURRENT_TENANT`, the task-local every `tenant_scoped`
+repository finder filters by (`autumn-macros/src/repository.rs` ~line 1913,
+`::autumn_web::tenancy::CURRENT_TENANT.try_with(|t| t.clone())`).
 
-## 🧪 Reproduction
-
-Test: `autumn/tests/integration/cached_tenant_scope.rs` ::
-`cached_tenant_scoped_read_leaks_across_tenants`
-
-The test seeds two tenants' sentinel rows in a `tenant_scoped` model
-(`CtsWidget`), mirrors the SaaS starter's `cached_project_count` shape but
-keys the cached read on a legitimate non-tenant parameter (`format`,
-mirroring the starter's own "keep the repository handle out of the key"
-comment — just applied to the wrong parameter), and drives it through a real
-HTTP route (`GET /widgets/summary`) via `TestApp`/header-based tenancy,
-exactly as `docs/security/2026-09-02-idempotency-tenant-scope/` does for the
-idempotency cache.
-
-The committed test is `#[ignore = "requires Docker (testcontainers)"]`
-(per `CLAUDE.md`'s Integration Test Layout Guidelines) and is picked up
-automatically by CI's Docker-dependent test sweep — no workflow edit. This
-sandbox has no Docker daemon, so the red/green runs below were captured with
-an identical scratch harness (same fixtures, same assertions) pointed at a
-natively-installed PostgreSQL 16 service on `127.0.0.1:5432` instead of a
-testcontainer; the only difference from the committed test is the pool's
-connection source. The fix itself was verified reverted-and-restored
-in place (`git stash`) against the *same* running Postgres instance, so the
-red and green runs below differ by exactly the `autumn-macros/src/cached.rs`
-change and nothing else.
-
-Command: `cargo test -p autumn-web --test <scratch> --features
-"db,cache-moka,test-support" -- --nocapture`
-
-Failure output on trunk (fix reverted): see `trunk-failure.txt` —
-
-```
-thread 'cached_tenant_scoped_read_leaks_across_tenants' panicked at ...:170:5:
-tenant B received tenant A's cached #[cached] response body: "csv:tenant-a-sentinel"
-(the cache key never carried the resolved tenant)
-test cached_tenant_scoped_read_leaks_across_tenants ... FAILED
-```
+The build-time cache-coherence gate (`autumn-cli/src/cache_audit.rs`,
+`autumn cache audit`) proves only *staleness* — that a cached read's declared
+or derived model dependencies are covered by a repository's
+`invalidates(...)` clause. It has no notion of tenant-key correctness, so a
+`#[cached(reads(TenantScopedModel))]` function with no tenant-identifying key
+parameter compiles, passes the audit, and runs.
 
 ## 🩹 Fix
 
-`autumn-macros/src/cached.rs`'s `generate_cache_body` now reads
-`CURRENT_TENANT` unconditionally and folds it into the key alongside
-whatever `key(...)` already names:
+`generate_cache_body` now reads `CURRENT_TENANT` unconditionally and folds it
+into the key alongside whatever `key(...)` already names:
 
 ```rust
 let __autumn_tenant_key_component: Option<String> =
-    ::autumn_web::tenancy::CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
-let __autumn_key = ::autumn_web::cache::make_cache_key(
+    CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
+let __autumn_key = make_cache_key(
     #id_expr,
     &(__autumn_tenant_key_component, #key_args),
 );
 ```
 
-Fixed at the enforcing layer (the macro that generates every `#[cached]`
-function's key), not at any one call site — every `#[cached]` function in
-every downstream app gets the fix on upgrade, with no code change required.
-`CURRENT_TENANT` resolves to `None` for apps that never enable tenancy and
-for any call outside a tenancy-scoped request (a background job, a
-scheduled sweep), so those keys are byte-identical to before.
+Fixed at the enforcing layer — the macro that generates every `#[cached]`
+function's key — not at the one call site this test names, so every
+downstream app is covered on upgrade with no code change. `CURRENT_TENANT`
+resolves to `None` for apps without tenancy enabled and for any call outside
+a request (a background job, a scheduled sweep), so those keys are
+unchanged.
 
 ## ✅ Verification
 
-- `cached_tenant_scoped_read_leaks_across_tenants`: FAILED before the fix,
-  PASSED after (see `trunk-failure.txt` / `after.txt`).
-- `cargo test -p autumn-macros cached::` — all 40 existing `#[cached]`
-  macro-expansion unit tests pass unchanged (key selection, coherence
-  registration, fence/insert ordering, etc.) — the fix only adds a key
-  component, it doesn't change any existing one.
-- Re-attack: confirmed the *same*-tenant case still hits the cache
-  (repeat call from tenant A within the TTL still serves tenant A's own
-  cached value — the fix partitions by tenant, it doesn't disable caching).
+- Reproduction test: FAILED before the fix (`trunk-failure.txt`), PASSED
+  after (`after.txt`).
+- `cargo test -p autumn-macros cached::` — all 40 pre-existing `#[cached]`
+  macro-expansion unit tests pass unchanged.
+- `cargo test -p autumn-web --test integration_tests --features
+  "db,cache-moka,test-support" cache_coherence` — 16 passed, 0 failed; the
+  new test module compiles cleanly into the full 1934-test consolidated
+  binary alongside the existing cache-coherence suite.
+- `cargo clippy -p autumn-macros --lib -- -D warnings` and
+  `cargo fmt --all` — clean.
+- Re-attack: confirmed a same-tenant repeat call still hits the cache within
+  the TTL (the fix partitions by tenant; it does not disable caching).
 
 ## 📡 Blast radius
 
-- **Every `#[cached]` function is the same shape** — there is exactly one
-  code path that builds the runtime key
-  (`generate_cache_body`/`key_tuple`), so this is a single fix point, not a
-  per-call-site patch. Swept: no other function in `autumn-macros` or
-  `autumn/src/cache/*` independently constructs a `#[cached]`-style key.
-- **Feature gates:** `#[cached]`'s default backend is `cache-moka`; when a
-  process-level shared backend is registered (`autumn-cache-redis`,
-  `redis` feature) the same generated key is used as the store key, so the
-  fix covers that backend identically — verified by reading
-  `autumn/src/cache/mod.rs`'s `global_cache()` call site in the generated
-  body, which sits *after* the key is built.
-- **Cache coherence / `autumn cache audit`:** intentionally left alone —
-  it proves staleness (missing `invalidates(...)`), a different property
-  from tenant-key correctness, and adding a tenant-key lint there was
-  considered but the macro-level fix is strictly stronger (it fixes the
-  data race even for an app that never runs `autumn cache audit` in CI).
-- **Fragment cache (`autumn/src/cache/fragment.rs`) and read-through
-  (`autumn/src/cache/read_through.rs`)** build their keys from
-  caller-supplied strings, not function-argument hashing — out of scope
-  for this fix; a follow-up findings note may be warranted if either is
-  found to compute its key without an app-supplied tenant discriminator,
-  but neither is macro-generated the way `#[cached]` is, so an app calling
-  them incorrectly is the "app held it wrong" shape, not this one.
+- Single fix point: every `#[cached]` function shares the same
+  key-construction code path (`generate_cache_body` / `key_tuple`) — no other
+  site independently builds a `#[cached]`-style key.
+- Applies identically to both cache backends: the key is built before
+  `global_cache()` backend selection, so the Moka default and the
+  `autumn-cache-redis` shared backend both use the fixed key.
+- `autumn cache audit` / the cache-coherence gate is intentionally untouched
+  — it proves a different property (staleness, not tenant isolation); the
+  macro-level fix is strictly stronger since it protects apps that never run
+  the audit at all.
+- Checked and out of scope: `autumn/src/cache/fragment.rs` and
+  `cache/read_through.rs` build keys from caller-supplied strings, not
+  macro-generated argument hashing — an app misusing those directly by hand
+  is the "held it wrong, no gate" shape, not this one.
+- Affects every released `autumn-web` version that shipped `#[cached]`.
 
 ## 📜 Compatibility
 
-- No public macro *input* syntax changed (`key(...)`, `ttl`, `reads(...)`,
-  etc. are unchanged) — per `STABILITY.md`, `#[cached]`'s generated code is
-  explicitly not part of the semver-covered surface.
-- Behavior change, called out in `CHANGELOG.md` under `## [Unreleased]` →
-  `### Security`: a `#[cached]` function that intentionally serves one
-  shared, cross-tenant value now partitions its cache per resolved tenant
-  too, when called from within a tenant's request. This is a hit-rate
-  regression for that (out-of-contract for `tenant_scoped` data) usage, not
-  a correctness change — the computed value doesn't vary by tenant, so a
-  cache miss just recomputes the same answer once per tenant instead of
-  once globally.
+- No macro *input* syntax changed; per `STABILITY.md`, `#[cached]`'s
+  generated code is explicitly not SemVer-covered.
+- Behavior change, recorded in `CHANGELOG.md` under `## [Unreleased]` →
+  `### Security`: a `#[cached]` function intentionally serving one shared,
+  cross-tenant value (a genuinely global computation, not a `tenant_scoped`
+  read) now partitions its cache per resolved tenant too when called from
+  within a tenant's request — a hit-rate regression for that out-of-contract
+  usage, not a correctness change.
 - No config default changed; no migration required.
-
-## 🗂 Ledger
-
-- `trunk-failure.txt` — red run (fix reverted)
-- `after.txt` — green run (fix applied)

--- a/docs/security/2026-09-05-cached-tenant-key/README.md
+++ b/docs/security/2026-09-05-cached-tenant-key/README.md
@@ -1,0 +1,174 @@
+# Cross-tenant `#[cached]` read via a tenant-blind cache key (2026-09-05)
+
+**Class:** cross-tenant read through an authenticated surface
+**Surface:** `autumn-macros::cached` — `#[cached]`'s generated cache-key
+construction
+**Entry point:** any HTTP route (or any code path) that calls a `#[cached]`
+function memoizing a `tenant_scoped` `#[repository]` read
+**Affected:** `autumn-web` 0.7.0 and every earlier release that shipped
+`#[cached]`
+**Status:** fixed — `autumn-macros/src/cached.rs`
+
+## 🕵️ Threat model
+
+> Against an app that follows Autumn's own documented patterns — turns on
+> multi-tenancy (`[tenancy] enabled = true`, per `docs/guide/tenant-cells.md`)
+> and memoizes a `tenant_scoped` repository read with `#[cached]` (per
+> `docs/guide/cache-coherence.md`, exactly as the framework's own SaaS starter
+> does in `examples/saas/src/repositories.rs`) — an attacker who is an
+> ordinary authenticated principal of tenant B can obtain **tenant A's cached
+> response** from any such cached read, for the remainder of the entry's TTL,
+> simply by calling the same route/function with the same *non-tenant*
+> arguments tenant A used. The app author did nothing the documentation told
+> them not to do: the SaaS starter's own `cached_project_count` is the
+> *correct* pattern (thread `tenant_id` explicitly and name it in
+> `key(tenant_id)`), but nothing in the macro, the build-time cache-coherence
+> gate (`autumn cache audit`), or `autumn routes audit` detects or prevents
+> its omission — and every *other* `tenant_scoped` operation in Autumn
+> resolves the tenant from the ambient `CURRENT_TENANT` task-local
+> automatically, with no explicit parameter required. A developer who caches
+> a `tenant_scoped` read keyed on some other legitimate, real parameter
+> (a page number, an export format, a filter) instead of the tenant has
+> followed the framework's own ambient-scoping idiom everywhere else — and
+> been bitten by the one place it silently doesn't apply.
+
+## 🔎 Root cause
+
+`autumn-macros/src/cached.rs`'s `generate_cache_body` builds the runtime
+key as:
+
+```rust
+let __autumn_key = ::autumn_web::cache::make_cache_key(#id_expr, #key_args);
+```
+
+`#key_args` (from `key_tuple`) is built exclusively from the function's own
+*explicit* parameters — every parameter by default, or exactly the
+parameters named in `key(...)` when present (`autumn-macros/src/cached.rs`
+`key_tuple`, ~line 489). It never reads `autumn_web::tenancy::CURRENT_TENANT`
+— the task-local a `tenant_scoped` repository read filters by
+(`autumn-macros/src/repository.rs` ~line 1913: `CURRENT_TENANT.try_with(...)`
+inside every `tenant_scoped` finder). The build-time cache-coherence gate
+(`autumn-cli/src/cache_audit.rs`) proves only *staleness* edges (a cached
+read's declared/derived model dependencies vs. a repository's
+`invalidates(...)` clause) — it has no notion of tenant-key correctness at
+all, so a `#[cached(reads(TenantScopedModel))]` function with no
+tenant-identifying key parameter compiles, passes `autumn cache audit`, and
+runs.
+
+## 🧪 Reproduction
+
+Test: `autumn/tests/integration/cached_tenant_scope.rs` ::
+`cached_tenant_scoped_read_leaks_across_tenants`
+
+The test seeds two tenants' sentinel rows in a `tenant_scoped` model
+(`CtsWidget`), mirrors the SaaS starter's `cached_project_count` shape but
+keys the cached read on a legitimate non-tenant parameter (`format`,
+mirroring the starter's own "keep the repository handle out of the key"
+comment — just applied to the wrong parameter), and drives it through a real
+HTTP route (`GET /widgets/summary`) via `TestApp`/header-based tenancy,
+exactly as `docs/security/2026-09-02-idempotency-tenant-scope/` does for the
+idempotency cache.
+
+The committed test is `#[ignore = "requires Docker (testcontainers)"]`
+(per `CLAUDE.md`'s Integration Test Layout Guidelines) and is picked up
+automatically by CI's Docker-dependent test sweep — no workflow edit. This
+sandbox has no Docker daemon, so the red/green runs below were captured with
+an identical scratch harness (same fixtures, same assertions) pointed at a
+natively-installed PostgreSQL 16 service on `127.0.0.1:5432` instead of a
+testcontainer; the only difference from the committed test is the pool's
+connection source. The fix itself was verified reverted-and-restored
+in place (`git stash`) against the *same* running Postgres instance, so the
+red and green runs below differ by exactly the `autumn-macros/src/cached.rs`
+change and nothing else.
+
+Command: `cargo test -p autumn-web --test <scratch> --features
+"db,cache-moka,test-support" -- --nocapture`
+
+Failure output on trunk (fix reverted): see `trunk-failure.txt` —
+
+```
+thread 'cached_tenant_scoped_read_leaks_across_tenants' panicked at ...:170:5:
+tenant B received tenant A's cached #[cached] response body: "csv:tenant-a-sentinel"
+(the cache key never carried the resolved tenant)
+test cached_tenant_scoped_read_leaks_across_tenants ... FAILED
+```
+
+## 🩹 Fix
+
+`autumn-macros/src/cached.rs`'s `generate_cache_body` now reads
+`CURRENT_TENANT` unconditionally and folds it into the key alongside
+whatever `key(...)` already names:
+
+```rust
+let __autumn_tenant_key_component: Option<String> =
+    ::autumn_web::tenancy::CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
+let __autumn_key = ::autumn_web::cache::make_cache_key(
+    #id_expr,
+    &(__autumn_tenant_key_component, #key_args),
+);
+```
+
+Fixed at the enforcing layer (the macro that generates every `#[cached]`
+function's key), not at any one call site — every `#[cached]` function in
+every downstream app gets the fix on upgrade, with no code change required.
+`CURRENT_TENANT` resolves to `None` for apps that never enable tenancy and
+for any call outside a tenancy-scoped request (a background job, a
+scheduled sweep), so those keys are byte-identical to before.
+
+## ✅ Verification
+
+- `cached_tenant_scoped_read_leaks_across_tenants`: FAILED before the fix,
+  PASSED after (see `trunk-failure.txt` / `after.txt`).
+- `cargo test -p autumn-macros cached::` — all 40 existing `#[cached]`
+  macro-expansion unit tests pass unchanged (key selection, coherence
+  registration, fence/insert ordering, etc.) — the fix only adds a key
+  component, it doesn't change any existing one.
+- Re-attack: confirmed the *same*-tenant case still hits the cache
+  (repeat call from tenant A within the TTL still serves tenant A's own
+  cached value — the fix partitions by tenant, it doesn't disable caching).
+
+## 📡 Blast radius
+
+- **Every `#[cached]` function is the same shape** — there is exactly one
+  code path that builds the runtime key
+  (`generate_cache_body`/`key_tuple`), so this is a single fix point, not a
+  per-call-site patch. Swept: no other function in `autumn-macros` or
+  `autumn/src/cache/*` independently constructs a `#[cached]`-style key.
+- **Feature gates:** `#[cached]`'s default backend is `cache-moka`; when a
+  process-level shared backend is registered (`autumn-cache-redis`,
+  `redis` feature) the same generated key is used as the store key, so the
+  fix covers that backend identically — verified by reading
+  `autumn/src/cache/mod.rs`'s `global_cache()` call site in the generated
+  body, which sits *after* the key is built.
+- **Cache coherence / `autumn cache audit`:** intentionally left alone —
+  it proves staleness (missing `invalidates(...)`), a different property
+  from tenant-key correctness, and adding a tenant-key lint there was
+  considered but the macro-level fix is strictly stronger (it fixes the
+  data race even for an app that never runs `autumn cache audit` in CI).
+- **Fragment cache (`autumn/src/cache/fragment.rs`) and read-through
+  (`autumn/src/cache/read_through.rs`)** build their keys from
+  caller-supplied strings, not function-argument hashing — out of scope
+  for this fix; a follow-up findings note may be warranted if either is
+  found to compute its key without an app-supplied tenant discriminator,
+  but neither is macro-generated the way `#[cached]` is, so an app calling
+  them incorrectly is the "app held it wrong" shape, not this one.
+
+## 📜 Compatibility
+
+- No public macro *input* syntax changed (`key(...)`, `ttl`, `reads(...)`,
+  etc. are unchanged) — per `STABILITY.md`, `#[cached]`'s generated code is
+  explicitly not part of the semver-covered surface.
+- Behavior change, called out in `CHANGELOG.md` under `## [Unreleased]` →
+  `### Security`: a `#[cached]` function that intentionally serves one
+  shared, cross-tenant value now partitions its cache per resolved tenant
+  too, when called from within a tenant's request. This is a hit-rate
+  regression for that (out-of-contract for `tenant_scoped` data) usage, not
+  a correctness change — the computed value doesn't vary by tenant, so a
+  cache miss just recomputes the same answer once per tenant instead of
+  once globally.
+- No config default changed; no migration required.
+
+## 🗂 Ledger
+
+- `trunk-failure.txt` — red run (fix reverted)
+- `after.txt` — green run (fix applied)

--- a/docs/security/2026-09-05-cached-tenant-key/after.txt
+++ b/docs/security/2026-09-05-cached-tenant-key/after.txt
@@ -1,5 +1,8 @@
-   Compiling autumn-macros v0.7.0 (/home/user/autumn/autumn-macros)
-   Compiling autumn-web v0.7.0 (/home/user/autumn/autumn)
+$ cargo test -p autumn-web --test warden_scratch_cached_tenant --features "db,cache-moka,test-support" -- --nocapture
+(same scratch harness as trunk-failure.txt, `autumn-macros/src/cached.rs` fix restored)
+
+    Compiling autumn-macros v0.7.0 (/home/user/autumn/autumn-macros)
+    Compiling autumn-web v0.7.0 (/home/user/autumn/autumn)
     Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 50s
      Running tests/warden_scratch_cached_tenant.rs (target/debug/deps/warden_scratch_cached_tenant-608dc226925a39c7)
 
@@ -8,3 +11,66 @@ test cached_tenant_scoped_read_leaks_across_tenants ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
 
+
+$ cargo test -p autumn-macros cached::
+running 40 tests
+test cached::tests::a_repository_mentioned_twice_is_recorded_once ... ok
+test cached::tests::a_qualified_repository_path_keeps_only_the_type_segments ... ok
+test cached::tests::a_destructuring_parameter_still_enters_the_key_as_a_pattern ... ok
+test cached::tests::a_repository_reached_only_through_its_trait_is_undetermined ... ok
+test cached::tests::derivation_finds_nothing_in_a_pure_function ... ok
+test cached::tests::default_max_capacity ... ok
+test cached::tests::derivation_ignores_non_repository_camel_case_types ... ok
+test cached::tests::a_repository_whose_name_differs_from_its_model_is_not_guessed_from_the_name ... ok
+test cached::tests::derivation_is_sorted_and_deduplicated ... ok
+test cached::tests::derives_dependencies_from_model_finder_calls_in_the_body ... ok
+test cached::tests::derives_dependencies_from_repository_types_in_the_signature ... ok
+test cached::tests::every_use_of_the_identity_is_the_same_expression ... ok
+test cached::tests::generated_output_marks_body_derived_reads_derived ... ok
+test cached::tests::generated_output_carries_the_acknowledged_stale_reason ... ok
+test cached::tests::generated_output_marks_underivable_reads_undetermined ... ok
+test cached::tests::generated_output_registers_a_declared_cached_read ... ok
+test cached::tests::generated_output_result_mode ... ok
+test cached::tests::generated_output_uses_moka ... ok
+test cached::tests::key_naming_an_unknown_parameter_is_a_compile_error ... ok
+test cached::tests::key_matches_a_mut_binding_by_its_name ... ok
+test cached::tests::key_narrows_the_cache_key_to_the_named_parameters ... ok
+test cached::tests::parse_acknowledge_stale_requires_a_nonempty_reason ... ok
+test cached::tests::parse_empty_attrs ... ok
+test cached::tests::parse_all_attrs ... ok
+test cached::tests::parse_empty_key_is_an_error ... ok
+test cached::tests::parse_empty_reads_is_an_error ... ok
+test cached::tests::parse_key_selects_the_key_parameters ... ok
+test cached::tests::parse_max_as_integer ... ok
+test cached::tests::no_args_function ... ok
+test cached::tests::parse_reads_declares_the_dependency_set ... ok
+test cached::tests::parse_result_flag_only ... ok
+test cached::tests::parse_reads_accepts_qualified_paths ... ok
+test cached::tests::parse_ttl_only ... ok
+test cached::tests::parse_unknown_attr_errors ... ok
+test cached::tests::self_receiver_errors ... ok
+test cached::tests::the_expansion_fences_a_fill_against_a_concurrent_invalidation ... ok
+test cached::tests::result_mode_fences_its_insert_too ... ok
+test cached::tests::the_expansion_survives_a_shadowed_str_or_bool ... ok
+test cached::tests::without_key_every_parameter_still_enters_the_cache_key ... ok
+test cached::tests::the_insert_happens_inside_the_fence_not_merely_after_a_check ... ok
+
+test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 1033 filtered out; finished in 0.01s
+
+
+$ cargo test -p autumn-web --test integration_tests --features "db,cache-moka,test-support" cache_coherence
+[dependency compile output omitted]
+test [1mtests/compile-fail/cached_reads_empty.rs[0m ... ok
+test [1mtests/compile-fail/cached_acknowledge_stale_blank_reason.rs[0m ... ok
+test [1mtests/compile-fail/repository_invalidates_unknown_read.rs[0m ... ok
+test [1mtests/compile-fail/repository_invalidates_empty.rs[0m ... ok
+test [1mtests/compile-fail/repository_acknowledge_stale_blank_reason.rs[0m ... ok
+
+test integration::compile_fail::cache_coherence_compile_fail_tests ... ok
+
+test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 1918 filtered out; finished in 268.46s
+
+(this run also confirms the new `cached_tenant_scope` module — registered in
+`autumn/tests/integration/mod.rs` — compiles cleanly into the full 1934-test
+consolidated `integration_tests` binary alongside the pre-existing
+cache-coherence suite, unaffected by the fix.)

--- a/docs/security/2026-09-05-cached-tenant-key/after.txt
+++ b/docs/security/2026-09-05-cached-tenant-key/after.txt
@@ -1,0 +1,10 @@
+   Compiling autumn-macros v0.7.0 (/home/user/autumn/autumn-macros)
+   Compiling autumn-web v0.7.0 (/home/user/autumn/autumn)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 50s
+     Running tests/warden_scratch_cached_tenant.rs (target/debug/deps/warden_scratch_cached_tenant-608dc226925a39c7)
+
+running 1 test
+test cached_tenant_scoped_read_leaks_across_tenants ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
+

--- a/docs/security/2026-09-05-cached-tenant-key/trunk-failure.txt
+++ b/docs/security/2026-09-05-cached-tenant-key/trunk-failure.txt
@@ -1,0 +1,75 @@
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.50s
+     Running tests/warden_scratch_cached_tenant.rs (target/debug/deps/warden_scratch_cached_tenant-608dc226925a39c7)
+
+running 1 test
+
+thread 'cached_tenant_scoped_read_leaks_across_tenants' (9171) panicked at autumn/tests/warden_scratch_cached_tenant.rs:170:5:
+tenant B received tenant A's cached #[cached] response body: "csv:tenant-a-sentinel" (the cache key never carried the resolved tenant)
+stack backtrace:
+   0: __rustc::rust_begin_unwind
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/panicking.rs:689:5
+   1: core::panicking::panic_fmt
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/panicking.rs:80:14
+   2: {async_block#0}
+             at ./tests/warden_scratch_cached_tenant.rs:170:5
+   3: poll<&mut dyn core::future::future::Future<Output=()>>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
+   4: poll<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
+   5: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:70
+   6: with_budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:167:5
+   7: budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:133:5
+   8: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:25
+   9: tokio::runtime::scheduler::current_thread::Context::enter
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:488:19
+  10: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:829:44
+  11: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:68
+  12: tokio::runtime::context::scoped::Scoped<T>::set
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/scoped.rs:40:9
+  13: tokio::runtime::context::set_scheduler::{{closure}}
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:38
+  14: try_with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>), tokio::runtime::scheduler::current_thread::{impl#9}::enter::{closure_env#0}<tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>, core::option::Option<()>>>, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>)>
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:513:12
+  15: std::thread::local::LocalKey<T>::with
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:477:20
+  16: tokio::runtime::context::set_scheduler
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:17
+  17: tokio::runtime::scheduler::current_thread::CoreGuard::enter
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:27
+  18: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:817:24
+  19: {closure#0}<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:218:33
+  20: tokio::runtime::context::runtime::enter_runtime
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/runtime.rs:65:16
+  21: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:206:9
+  22: tokio::runtime::runtime::Runtime::block_on_inner
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:374:52
+  23: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
+             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:343:18
+  24: cached_tenant_scoped_read_leaks_across_tenants
+             at ./tests/warden_scratch_cached_tenant.rs:180:6
+  25: warden_scratch_cached_tenant::cached_tenant_scoped_read_leaks_across_tenants::{{closure}}
+             at ./tests/warden_scratch_cached_tenant.rs:129:58
+  26: core::ops::function::FnOnce::call_once
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
+  27: core::ops::function::FnOnce::call_once
+             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
+note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
+test cached_tenant_scoped_read_leaks_across_tenants ... FAILED
+
+failures:
+
+failures:
+    cached_tenant_scoped_read_leaks_across_tenants
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s
+
+error: test failed, to rerun pass `-p autumn-web --test warden_scratch_cached_tenant`

--- a/docs/security/2026-09-05-cached-tenant-key/trunk-failure.txt
+++ b/docs/security/2026-09-05-cached-tenant-key/trunk-failure.txt
@@ -1,5 +1,10 @@
-    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.50s
-     Running tests/warden_scratch_cached_tenant.rs (target/debug/deps/warden_scratch_cached_tenant-608dc226925a39c7)
+$ cargo test -p autumn-web --test warden_scratch_cached_tenant --features "db,cache-moka,test-support" -- --nocapture
+(scratch verification harness — identical logic to the committed
+`autumn/tests/integration/cached_tenant_scope.rs`, but its `setup_pool()`
+points at a natively-installed PostgreSQL 16 service on 127.0.0.1:5432
+instead of spinning up a `testcontainers` container — this sandbox had no
+Docker daemon available. `autumn-macros/src/cached.rs` was reverted to its
+pre-fix state via `git stash` for this run, and restored immediately after.)
 
 running 1 test
 
@@ -7,65 +12,14 @@ thread 'cached_tenant_scoped_read_leaks_across_tenants' (9171) panicked at autum
 tenant B received tenant A's cached #[cached] response body: "csv:tenant-a-sentinel" (the cache key never carried the resolved tenant)
 stack backtrace:
    0: __rustc::rust_begin_unwind
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/panicking.rs:689:5
    1: core::panicking::panic_fmt
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/panicking.rs:80:14
    2: {async_block#0}
              at ./tests/warden_scratch_cached_tenant.rs:170:5
-   3: poll<&mut dyn core::future::future::Future<Output=()>>
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
-   4: poll<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/future/future.rs:133:9
-   5: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:70
-   6: with_budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:167:5
-   7: budget<core::task::poll::Poll<()>, tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure#0}::{closure#0}::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/task/coop/mod.rs:133:5
-   8: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:830:25
-   9: tokio::runtime::scheduler::current_thread::Context::enter
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:488:19
-  10: {closure#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:829:44
-  11: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:68
-  12: tokio::runtime::context::scoped::Scoped<T>::set
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/scoped.rs:40:9
-  13: tokio::runtime::context::set_scheduler::{{closure}}
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:38
-  14: try_with<tokio::runtime::context::Context, tokio::runtime::context::set_scheduler::{closure_env#0}<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>), tokio::runtime::scheduler::current_thread::{impl#9}::enter::{closure_env#0}<tokio::runtime::scheduler::current_thread::{impl#9}::block_on::{closure_env#0}<core::pin::Pin<&mut core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>>, core::option::Option<()>>>, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core, alloc::alloc::Global>, core::option::Option<()>)>
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:513:12
-  15: std::thread::local::LocalKey<T>::with
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/std/src/thread/local.rs:477:20
-  16: tokio::runtime::context::set_scheduler
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context.rs:187:17
-  17: tokio::runtime::scheduler::current_thread::CoreGuard::enter
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:906:27
-  18: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:817:24
-  19: {closure#0}<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:218:33
-  20: tokio::runtime::context::runtime::enter_runtime
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/context/runtime.rs:65:16
-  21: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/scheduler/current_thread/mod.rs:206:9
-  22: tokio::runtime::runtime::Runtime::block_on_inner
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:374:52
-  23: block_on<core::pin::Pin<&mut dyn core::future::future::Future<Output=()>>>
-             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.53.1/src/runtime/runtime.rs:343:18
+   [... tokio runtime frames omitted ...]
   24: cached_tenant_scoped_read_leaks_across_tenants
              at ./tests/warden_scratch_cached_tenant.rs:180:6
-  25: warden_scratch_cached_tenant::cached_tenant_scoped_read_leaks_across_tenants::{{closure}}
-             at ./tests/warden_scratch_cached_tenant.rs:129:58
-  26: core::ops::function::FnOnce::call_once
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
-  27: core::ops::function::FnOnce::call_once
-             at /rustc/e408947bfd200af42db322daf0fadfe7e26d3bd1/library/core/src/ops/function.rs:250:5
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
 test cached_tenant_scoped_read_leaks_across_tenants ... FAILED
-
-failures:
 
 failures:
     cached_tenant_scoped_read_leaks_across_tenants


### PR DESCRIPTION
## 🎯 Surface

`autumn-macros::cached` — `#[cached]`'s generated cache-key construction. Entry point: any HTTP route (or any other code path) that calls a `#[cached]` function memoizing a `tenant_scoped` `#[repository]` read.

## 🕵️ Threat model

Against an app that follows Autumn's own documented patterns — turns on multi-tenancy (`[tenancy] enabled = true`) and memoizes a `tenant_scoped` repository read with `#[cached]`, exactly as the framework's own SaaS starter does in `examples/saas/src/repositories.rs` — an attacker who is an ordinary authenticated principal of tenant B can obtain **tenant A's cached response** from any such cached read, for the remainder of the entry's TTL, simply by calling the same route/function with the same *non-tenant* arguments tenant A used.

The app author did nothing the documentation told them not to do: the SaaS starter's own `cached_project_count` is the *correct* pattern (thread `tenant_id` explicitly and name it in `key(tenant_id)`), but nothing in the macro, the build-time cache-coherence gate (`autumn cache audit`), or `autumn routes audit` detects or prevents its omission — and every *other* `tenant_scoped` operation in Autumn resolves the tenant from the ambient `CURRENT_TENANT` task-local automatically, with no explicit parameter required. A developer who caches a `tenant_scoped` read keyed on some other legitimate, real parameter (a page number, an export format, a filter) instead of the tenant has followed the framework's own ambient-scoping idiom everywhere else — and been bitten by the one place it silently doesn't apply.

## 🧪 Reproduction

Test: `autumn/tests/integration/cached_tenant_scope.rs::cached_tenant_scoped_read_leaks_across_tenants`

Seeds two tenants' sentinel rows in a `tenant_scoped` model, mirrors the SaaS starter's `cached_project_count` shape but keys the cached read on a legitimate non-tenant parameter (`format`), and drives it through a real HTTP route (`GET /widgets/summary`) via `TestApp` + header-based tenancy — same convention as `docs/security/2026-09-02-idempotency-tenant-scope/`.

The committed test is `#[ignore = "requires Docker (testcontainers)"]` per `CLAUDE.md`'s Integration Test Layout Guidelines, and is picked up automatically by CI's Docker sweep — no workflow edit. This sandbox had no Docker daemon, so the red/green runs in the ledger were captured with an identical scratch harness pointed at a natively-installed PostgreSQL 16 service instead of a testcontainer (only the pool's connection source differs); the fix was verified reverted-and-restored (`git stash`) against the same running Postgres, so the two runs differ by exactly the `cached.rs` change.

Failure output on trunk (fix reverted) — `docs/security/2026-09-05-cached-tenant-key/trunk-failure.txt`:
```
thread 'cached_tenant_scoped_read_leaks_across_tenants' panicked at ...:170:5:
tenant B received tenant A's cached #[cached] response body: "csv:tenant-a-sentinel"
(the cache key never carried the resolved tenant)
test cached_tenant_scoped_read_leaks_across_tenants ... FAILED
```

## 🔎 Root cause

`autumn-macros/src/cached.rs`'s `generate_cache_body` built the key as `make_cache_key(#id_expr, #key_args)`, where `#key_args` comes exclusively from the function's own explicit parameters (`key_tuple`, ~line 489) — every parameter by default, or exactly the parameters named in `key(...)`. It never read `autumn_web::tenancy::CURRENT_TENANT`, the task-local every `tenant_scoped` repository finder filters by (`autumn-macros/src/repository.rs` ~line 1913). The build-time cache-coherence gate (`autumn-cli/src/cache_audit.rs`) proves only *staleness* edges (declared/derived model dependencies vs. a repository's `invalidates(...)`) — it has no notion of tenant-key correctness, so a `#[cached(reads(TenantScopedModel))]` function with no tenant-identifying key parameter compiles, passes `autumn cache audit`, and runs.

## 🩹 Fix

`generate_cache_body` now reads `CURRENT_TENANT` unconditionally and folds it into the key alongside whatever `key(...)` already names:

```rust
let __autumn_tenant_key_component: Option<String> =
    CURRENT_TENANT.try_with(Clone::clone).ok().flatten();
let __autumn_key = make_cache_key(#id_expr, &(__autumn_tenant_key_component, #key_args));
```

Fixed at the enforcing layer — the macro that generates every `#[cached]` function's key — not at any one call site, so every downstream app gets the fix on upgrade with no code change. `CURRENT_TENANT` resolves to `None` for apps without tenancy enabled and for calls outside a request (a background job, a scheduled sweep), so those keys are unchanged.

## ✅ Verification

- Reproduction test: FAILED before the fix, PASSED after.
- `cargo test -p autumn-macros cached::` — all 40 existing `#[cached]` macro-expansion unit tests pass unchanged.
- `cargo test -p autumn-web --test integration_tests --features "db,cache-moka,test-support" cache_coherence` — 16 passed, 0 failed (existing cache-coherence suite unaffected; new test module compiles cleanly into the 1934-test consolidated binary).
- `cargo clippy -p autumn-macros --lib -- -D warnings` — clean (one pre-existing, unrelated `unknown_lints` warning from a clippy/lint-name version mismatch).
- `cargo fmt --all` — no changes.
- Re-attack: confirmed a same-tenant repeat call still hits the cache within the TTL — the fix partitions by tenant, it doesn't disable caching.

## 📡 Blast radius

- Single fix point: every `#[cached]` function shares the same key-construction code path (`generate_cache_body`/`key_tuple`); no other site independently builds a `#[cached]`-style key.
- Covers the `redis`-backed shared cache backend identically — the generated key is built before the `global_cache()` backend selection, so both Moka and Redis backends use the fixed key.
- `autumn cache audit` / cache-coherence gate intentionally left alone (proves a different property — staleness, not tenant isolation); the macro-level fix is strictly stronger since it protects apps that never run the audit.
- `autumn/src/cache/fragment.rs` and `read_through.rs` build keys from caller-supplied strings, not macro-generated argument hashing — out of scope here; an app misusing those directly is the "app held it wrong" shape, not this one.

## 📜 Compatibility

- No macro *input* syntax changed; per `STABILITY.md`, `#[cached]`'s generated code is explicitly not semver-covered.
- Behavior change (called out in `CHANGELOG.md` under `## [Unreleased]` → `### Security`): a `#[cached]` function intentionally serving one shared, cross-tenant value now partitions per resolved tenant too when called from within a tenant's request — a hit-rate regression for that out-of-contract usage, not a correctness change.
- No config default changed; no migration required.

## 🗂 Ledger

`docs/security/2026-09-05-cached-tenant-key/` (README, trunk-failure.txt, after.txt)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBKpeGM5tkbSnnhhYNVKVq


---
_Generated by [Claude Code](https://claude.ai/code/session_01TBKpeGM5tkbSnnhhYNVKVq)_