### PR TITLE
🧭 Wayfinder: redisplay signup/login forms on failure in saas & teams (error-path 0/6 → 6/6, email preserved)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,17 @@ jobs:
           # basecamp/kamal-proxy Docker Hub image) and needs the ssh client
           # installed above.
           cargo test -p autumn-cli --test deploy_e2e -- --ignored
+          # Example apps are NOT auto-swept the way autumn-web's consolidated
+          # `integration_tests` binary is (Codex review finding on #2530):
+          # `saas` and `teams` each have their own Docker-gated
+          # `tests/integration_test.rs` (signup -> login -> tenant-scoped
+          # flows, invite/accept, role gating, …) that otherwise never runs
+          # anywhere in CI. `--test-threads=1` because both suites share one
+          # process-global `TestDb::shared()` Postgres container and each
+          # test's setup does a `TRUNCATE` — concurrent tests would race each
+          # other's data, exactly as each file's own doc comment says.
+          cargo test -p saas -- --ignored --test-threads=1
+          cargo test -p teams -- --ignored --test-threads=1
 
   coverage:
     name: Coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1633,9 +1633,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lose that opt-in. Zero-membership and corrupt-role login failures in
   `teams` (real server-side conditions no resubmit can fix) are left as
   real error responses. Two new `#[ignore = "requires Docker
-  (testcontainers)"]` integration tests (one per app) prove all 6 cases
-  end-to-end; a third proves the remember-me checkbox survives a rejected
-  login both ticked and unticked.
+  (testcontainers)"]` integration tests (one per app) exercise all 6 cases
+  end-to-end, including the weak-password branch's email preservation (never
+  previously asserted for either app) and the over-long-input login case; a
+  third proves the remember-me checkbox survives a rejected login both ticked
+  and unticked. `saas` and `teams` were not previously part of CI's
+  Docker-dependent test sweep at all — unlike `autumn-web`'s consolidated
+  binary, example apps are not auto-swept — so `.github/workflows/ci.yml`
+  now runs both crates' `--ignored` suites explicitly (`--test-threads=1`:
+  both share one process-global `TestDb::shared()` container, and each
+  test's setup does a `TRUNCATE`).
 
 - **🔒 `autumn generate auth`: a concurrent successful login could be silently
   re-locked by a racing failed attempt (issue #2500):** the generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1604,6 +1604,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **🧭 Wayfinder: signup/login redisplay inline on failure in `saas` and
+  `teams` (error-path 1/6 → 6/6 redisplaying the form; 0/6 → 6/6 preserving
+  the entered email):** an error-path inventory of both starters' auth
+  flows — signup and login in the two `supported`-tier examples whose whole
+  purpose is demonstrating that journey — found 5 of 6 recoverable failure
+  modes (malformed email, over-long password, and duplicate email at signup;
+  invalid credentials and over-long input at login) returning
+  `AutumnError`'s generic `application/problem+json`/error-page response
+  instead of redisplaying the form; the sixth (a weak password at signup)
+  did redisplay but still dropped the email the user had already typed, since
+  neither `signup_page` nor `login_form` accepted an `email` parameter to
+  preserve it. Fix: every recoverable failure now redisplays the same form at
+  HTTP 200 with the message adjacent to the fields (the existing `role="alert"`
+  paragraph) and the entered email preserved via a new `value=` attribute —
+  the one convention the weak-password branch already established, now
+  applied consistently. `teams`'s duplicate-email case needed one extra step:
+  its three signup inserts run inside one DB transaction, so that failure is
+  classified (`AutumnError::conflict_msg`, matched by status after the
+  transaction) precisely on Diesel's `UniqueViolation` rather than any insert
+  error, so a real mid-transaction failure (a dropped connection, a
+  permission error) still propagates as the 500/503 it is instead of
+  rendering a fake-successful "could not create account" page — the same
+  precise match was applied to `saas`'s non-transactional insert. `saas`'s
+  login redisplay also threads the submitted "Remember me" checkbox state
+  back through (`checked[remember]`), so a user who ticks it, mistypes their
+  password, and corrects it without re-checking the box does not silently
+  lose that opt-in. Zero-membership and corrupt-role login failures in
+  `teams` (real server-side conditions no resubmit can fix) are left as
+  real error responses. Two new `#[ignore = "requires Docker
+  (testcontainers)"]` integration tests (one per app) prove all 6 cases
+  end-to-end; a third proves the remember-me checkbox survives a rejected
+  login both ticked and unticked.
+
 - **🔒 `autumn generate auth`: a concurrent successful login could be silently
   re-locked by a racing failed attempt (issue #2500):** the generated
   `login` handler (and the duplicated `reauth` step-up block) counted a

--- a/autumn-cli/src/starters/saas/src/routes/auth.rs
+++ b/autumn-cli/src/starters/saas/src/routes/auth.rs
@@ -182,29 +182,42 @@ pub async fn signup(
         .await;
     let user = match inserted {
         Ok(user) => user,
-        // A duplicate email hits the UNIQUE constraint; surface the same generic
-        // message a failed login does so the form does not enumerate accounts —
-        // now as an inline redisplay rather than a full navigation away from the
-        // form, matching every other signup failure mode above. Matched
-        // specifically on `UniqueViolation` (Codex review finding) so a
-        // transient DB failure (connection drop, permission error, schema
-        // mismatch) propagates as the real error it is — masking one as a
-        // fake-successful 200 "could not create account" page would both hide
-        // it from availability monitoring and let `SubmitTokenLayer` cache
-        // that 200 as a completed submission.
-        Err(diesel::result::Error::DatabaseError(
-            diesel::result::DatabaseErrorKind::UniqueViolation,
-            _,
-        )) => {
-            return Ok(signup_page(
-                password_cfg.min_length,
-                submit_token.token(),
-                &form.email,
-                Some("Could not create account"),
+        Err(err) => {
+            let err: AutumnError = err.into();
+            // A duplicate email hits the `users_email_key` UNIQUE constraint
+            // (Postgres's default name for an unnamed `UNIQUE` column, per
+            // `autumn-cli/src/schema/diff.rs`'s own brownfield-introspection
+            // tests); surface the same generic message a failed login does
+            // so the form does not enumerate accounts — now as an inline
+            // redisplay rather than a full navigation away from the form,
+            // matching every other signup failure mode above. Checked via
+            // the framework's own `unique_violation_field` (the same helper
+            // `examples/teams/src/routes/invitations.rs` uses), matched on
+            // the specific constraint name rather than any `UniqueViolation`
+            // (Codex review finding: `users_pkey` — e.g. a sequence left
+            // behind the table by an import — would otherwise also be
+            // misreported as "duplicate email"). Any other error, including
+            // a `UniqueViolation` on a different constraint, propagates as
+            // the real error it is — masking one as a fake-successful 200
+            // "could not create account" page would both hide it from
+            // availability monitoring and let `SubmitTokenLayer` cache that
+            // 200 as a completed submission.
+            if autumn_web::error::unique_violation_field(
+                &err,
+                &[("users_email_key", "email", "Could not create account")],
             )
-            .into_response());
+            .is_some()
+            {
+                return Ok(signup_page(
+                    password_cfg.min_length,
+                    submit_token.token(),
+                    &form.email,
+                    Some("Could not create account"),
+                )
+                .into_response());
+            }
+            return Err(err);
         }
-        Err(err) => return Err(err.into()),
     };
 
     establish_session(&session, &user).await;

--- a/autumn-cli/src/starters/saas/src/routes/auth.rs
+++ b/autumn-cli/src/starters/saas/src/routes/auth.rs
@@ -51,7 +51,7 @@ const DUMMY_HASH: &str = "$2b$12$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s1Aw6lfLP2.GvpAfN
 /// cannot create a duplicate account — no client-side JavaScript involved. A
 /// new token is minted on every render (including this error re-render), so the
 /// corrected resubmit carries a fresh token rather than a spent one.
-fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Markup {
+fn signup_page(min_len: usize, submit_token: &str, email: &str, error: Option<&str>) -> Markup {
     layout(
         "Sign up",
         false,
@@ -64,7 +64,7 @@ fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Marku
                 input type="hidden" name="_submit_token" value=(submit_token);
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -89,6 +89,7 @@ pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToke
     signup_page(
         state.config_arc().auth.password.min_length,
         submit_token.token(),
+        "",
         None,
     )
 }
@@ -104,27 +105,42 @@ pub async fn signup(
     mut db: Db,
     Form(form): Form<SignupForm>,
 ) -> AutumnResult<Response> {
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section just to read `[auth.password]` on a request path.
+    // Read once up front so every re-render below (including the two input
+    // checks that used to bypass the form entirely) can reach `min_length`.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
+
     let email = form.email.trim().to_lowercase();
     // Cap input lengths so an attacker cannot drive bcrypt/DB work with huge
     // payloads (254 is the RFC-5321 email maximum; 128 is a generous password cap).
+    // Both used to `Err(...)` out to the generic JSON/error-page response,
+    // dropping the user off the form and losing the email they typed; they now
+    // redisplay the same form the password-policy failure below always has,
+    // with the entered email preserved (Wayfinder: error-path inventory).
     if !email.contains('@') || email.len() > 254 {
-        return Err(AutumnError::unprocessable_msg(
-            "Enter a valid email address (max 254 characters)",
-        ));
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            &form.email,
+            Some("Enter a valid email address (max 254 characters)"),
+        )
+        .into_response());
     }
     if form.password.len() > 128 {
-        return Err(AutumnError::unprocessable_msg(
-            "Password must be at most 128 characters",
-        ));
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            &form.email,
+            Some("Password must be at most 128 characters"),
+        )
+        .into_response());
     }
     // Enforce the configured password policy (length, weak-list, similarity to
     // the email, and optional HIBP breach check). On failure, re-render the form
     // with the specific message at HTTP 200 rather than accepting a weak
     // credential.
-    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
-    // deep-clone every section just to read `[auth.password]` on a request path.
-    let config = state.config_arc();
-    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {
         // Breach checking needs an HTTP client for the HIBP k-anonymity lookup;
@@ -144,6 +160,7 @@ pub async fn signup(
         return Ok(signup_page(
             password_cfg.min_length,
             submit_token.token(),
+            &form.email,
             Some(&message),
         )
         .into_response());
@@ -154,7 +171,7 @@ pub async fn signup(
     let tenant_id = email.clone();
     let password_hash = hash_password(&form.password).await?;
 
-    let user: User = diesel::insert_into(users::table)
+    let inserted = diesel::insert_into(users::table)
         .values(&NewUser {
             email,
             password_hash,
@@ -162,10 +179,33 @@ pub async fn signup(
         })
         .returning(User::as_returning())
         .get_result(&mut *db)
-        .await
+        .await;
+    let user = match inserted {
+        Ok(user) => user,
         // A duplicate email hits the UNIQUE constraint; surface the same generic
-        // message a failed login does so the form does not enumerate accounts.
-        .map_err(|_| AutumnError::unprocessable_msg("Could not create account"))?;
+        // message a failed login does so the form does not enumerate accounts —
+        // now as an inline redisplay rather than a full navigation away from the
+        // form, matching every other signup failure mode above. Matched
+        // specifically on `UniqueViolation` (Codex review finding) so a
+        // transient DB failure (connection drop, permission error, schema
+        // mismatch) propagates as the real error it is — masking one as a
+        // fake-successful 200 "could not create account" page would both hide
+        // it from availability monitoring and let `SubmitTokenLayer` cache
+        // that 200 as a completed submission.
+        Err(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            _,
+        )) => {
+            return Ok(signup_page(
+                password_cfg.min_length,
+                submit_token.token(),
+                &form.email,
+                Some("Could not create account"),
+            )
+            .into_response());
+        }
+        Err(err) => return Err(err.into()),
+    };
 
     establish_session(&session, &user).await;
     Ok(Redirect::to("/dashboard").into_response())
@@ -175,15 +215,28 @@ pub async fn signup(
 
 #[get("/login")]
 pub async fn login_form() -> Markup {
+    login_page("", false, None)
+}
+
+/// `email` re-populates the field and `remember` re-checks the "Remember me"
+/// box on an error redisplay (Codex review finding: a corrected resubmit
+/// must not silently drop an opt-in the user already made); `error`, when
+/// present, is shown above the form (Wayfinder: error-path inventory — the
+/// message must sit adjacent to the form that caused it, and what the user
+/// already entered/chose must not be thrown away).
+fn login_page(email: &str, remember: bool, error: Option<&str>) -> Markup {
     layout(
         "Log in",
         false,
         html! {
             h1 class="text-2xl font-bold mb-6" { "Log in" }
+            @if let Some(error) = error {
+                p class="mb-4 text-sm text-red-600" role="alert" { (error) }
+            }
             form action="/login" method="post" class="space-y-4 bg-white rounded-lg shadow p-6 max-w-md" {
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -192,7 +245,7 @@ pub async fn login_form() -> Markup {
                           autocomplete="current-password" class="w-full border rounded px-3 py-2";
                 }
                 label class="flex items-center gap-2 text-sm text-gray-600" {
-                    input #remember type="checkbox" name="remember" value="on"
+                    input #remember type="checkbox" name="remember" value="on" checked[remember]
                           class="rounded border-gray-300";
                     "Remember me on this device"
                 }
@@ -216,11 +269,17 @@ pub async fn login(
     headers: HeaderMap,
     Form(form): Form<LoginForm>,
 ) -> AutumnResult<Response> {
+    let remember = form.remember.is_some();
     let email = form.email.trim().to_lowercase();
     // Reject over-long inputs before any DB query or bcrypt work — they can never
-    // match a stored account and only waste CPU.
+    // match a stored account and only waste CPU. Redisplayed inline rather than
+    // sent to a generic error page, same as every failure mode below — a
+    // navigating browser was on the login form and should stay there
+    // (Wayfinder: error-path inventory).
     if email.len() > 254 || form.password.len() > 128 {
-        return Err(AutumnError::unauthorized_msg("Invalid email or password"));
+        return Ok(
+            login_page(&form.email, remember, Some("Invalid email or password")).into_response(),
+        );
     }
 
     let user: Option<User> = users::table
@@ -230,7 +289,6 @@ pub async fn login(
         .await
         .optional()?;
 
-    let invalid = || AutumnError::unauthorized_msg("Invalid email or password");
     // Always run a bcrypt verification so the response time is constant whether
     // or not the email exists — prevents a timing side-channel that reveals
     // which accounts are registered.
@@ -238,11 +296,16 @@ pub async fn login(
         Some(u) => u,
         None => {
             let _ = verify_password(&form.password, DUMMY_HASH).await;
-            return Err(invalid());
+            return Ok(
+                login_page(&form.email, remember, Some("Invalid email or password"))
+                    .into_response(),
+            );
         }
     };
     if !verify_password(&form.password, &user.password_hash).await? {
-        return Err(invalid());
+        return Ok(
+            login_page(&form.email, remember, Some("Invalid email or password")).into_response(),
+        );
     }
 
     establish_session(&session, &user).await;
@@ -256,7 +319,7 @@ pub async fn login(
     // `[auth.remember]` section below — `config()` would deep-clone the whole
     // config twice per login.
     let config = state.config_arc();
-    if form.remember.is_some() && config.auth.remember.enabled {
+    if remember && config.auth.remember.enabled {
         // Thread the resolved `[auth.remember]` config so cookie_name/duration
         // overrides are honoured (issue #1397.2).
         let remember_cfg = &config.auth.remember;

--- a/autumn-cli/src/starters/saas/tests/integration_test.rs
+++ b/autumn-cli/src/starters/saas/tests/integration_test.rs
@@ -276,13 +276,113 @@ async fn signup_rejects_weak_password() {
         resp.text()
     );
 
-    // No account was created, so logging in with those credentials fails.
+    // No account was created, so logging in with those credentials fails —
+    // the login form re-renders inline with the generic message at HTTP 200,
+    // the same convention as the signup failure above (Wayfinder: error-path
+    // inventory), rather than a full navigation to a generic error page.
     let login = client
         .post("/login")
         .form("email=weak@acme.test&password=password")
         .send()
         .await;
-    login.assert_status(401);
+    login.assert_ok();
+    assert!(
+        login.text().contains("Invalid email or password"),
+        "expected the login form to redisplay inline with the auth error, got: {}",
+        login.text()
+    );
+}
+
+/// Every recoverable signup/login failure mode redisplays the form inline
+/// (HTTP 200, same page, error adjacent to the fields) with the entered email
+/// preserved, instead of navigating the user to a generic error page and
+/// losing what they typed (Wayfinder: error-path inventory).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
+    let client = db_client().await;
+
+    // Malformed email at signup.
+    let resp = client
+        .post("/signup")
+        .form("email=not-an-email&password=Tr0ubad0ur-Xy7-correct-horse")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Enter a valid email address"));
+    assert!(
+        resp.text().contains(r#"value="not-an-email""#),
+        "expected the entered email to be preserved in the re-rendered form, got: {}",
+        resp.text()
+    );
+
+    // Over-long password at signup.
+    let long_password = "x".repeat(129);
+    let resp = client
+        .post("/signup")
+        .form(&format!("email=long@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("at most 128 characters"));
+    assert!(resp.text().contains(r#"value="long@acme.test""#));
+
+    // Duplicate email at signup: the first signup succeeds, the second is
+    // redisplayed inline rather than dropped onto a generic error page.
+    let _ = signup(&client, "dupe@acme.test").await;
+    let resp = client
+        .post("/signup")
+        .form("email=dupe@acme.test&password=Tr0ubad0ur-Xy7-correct-horse-2")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Could not create account"));
+    assert!(resp.text().contains(r#"value="dupe@acme.test""#));
+
+    // Invalid credentials at login preserve the entered (nonexistent) email.
+    let resp = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password-entirely")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="nobody@acme.test""#));
+}
+
+/// A "Remember me" opt-in must survive a rejected login (Codex review
+/// finding): if the user ticks the box, mistypes the password, and corrects
+/// it on the redisplayed form without re-checking a box they already
+/// checked, the eventual successful login must still honor their original
+/// choice — so the checkbox itself must come back checked.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn login_failure_preserves_the_remember_me_choice() {
+    let client = db_client().await;
+
+    let checked = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password&remember=on")
+        .send()
+        .await;
+    checked.assert_ok();
+    assert!(
+        checked.text().contains("checked"),
+        "expected the Remember-me checkbox to stay checked after a rejected login, got: {}",
+        checked.text()
+    );
+
+    let unchecked = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password")
+        .send()
+        .await;
+    unchecked.assert_ok();
+    assert!(
+        !unchecked.text().contains("checked"),
+        "an unticked box must not come back checked, got: {}",
+        unchecked.text()
+    );
 }
 
 #[tokio::test]

--- a/autumn-cli/src/starters/saas/tests/integration_test.rs
+++ b/autumn-cli/src/starters/saas/tests/integration_test.rs
@@ -327,6 +327,19 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     assert!(resp.text().contains("at most 128 characters"));
     assert!(resp.text().contains(r#"value="long@acme.test""#));
 
+    // Weak password at signup (the one branch that already redisplayed
+    // before this PR, but — per Codex review — was never itself asserted to
+    // preserve the entered email; `signup_rejects_weak_password` above only
+    // checks the policy message).
+    let resp = client
+        .post("/signup")
+        .form("email=weak2@acme.test&password=password")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("too common"));
+    assert!(resp.text().contains(r#"value="weak2@acme.test""#));
+
     // Duplicate email at signup: the first signup succeeds, the second is
     // redisplayed inline rather than dropped onto a generic error page.
     let _ = signup(&client, "dupe@acme.test").await;
@@ -348,6 +361,19 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     resp.assert_ok();
     assert!(resp.text().contains("Invalid email or password"));
     assert!(resp.text().contains(r#"value="nobody@acme.test""#));
+
+    // Over-long input at login (Codex review finding: the pre-existing
+    // "invalid credentials" case above exercises the same `login_page` call
+    // but not this distinct length-guard branch). Reuses the over-long
+    // password minted for the signup case above.
+    let resp = client
+        .post("/login")
+        .form(&format!("email=toolong@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="toolong@acme.test""#));
 }
 
 /// A "Remember me" opt-in must survive a rejected login (Codex review

--- a/examples/saas/src/routes/auth.rs
+++ b/examples/saas/src/routes/auth.rs
@@ -51,7 +51,7 @@ const DUMMY_HASH: &str = "$2b$12$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s1Aw6lfLP2.GvpAfN
 /// cannot create a duplicate account — no client-side JavaScript involved. A
 /// new token is minted on every render (including this error re-render), so the
 /// corrected resubmit carries a fresh token rather than a spent one.
-fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Markup {
+fn signup_page(min_len: usize, submit_token: &str, email: &str, error: Option<&str>) -> Markup {
     layout(
         "Sign up",
         false,
@@ -64,7 +64,7 @@ fn signup_page(min_len: usize, submit_token: &str, error: Option<&str>) -> Marku
                 input type="hidden" name="_submit_token" value=(submit_token);
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -89,6 +89,7 @@ pub async fn signup_form(State(state): State<AppState>, submit_token: SubmitToke
     signup_page(
         state.config_arc().auth.password.min_length,
         submit_token.token(),
+        "",
         None,
     )
 }
@@ -104,27 +105,42 @@ pub async fn signup(
     mut db: Db,
     Form(form): Form<SignupForm>,
 ) -> AutumnResult<Response> {
+    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
+    // deep-clone every section just to read `[auth.password]` on a request path.
+    // Read once up front so every re-render below (including the two input
+    // checks that used to bypass the form entirely) can reach `min_length`.
+    let config = state.config_arc();
+    let password_cfg = &config.auth.password;
+
     let email = form.email.trim().to_lowercase();
     // Cap input lengths so an attacker cannot drive bcrypt/DB work with huge
     // payloads (254 is the RFC-5321 email maximum; 128 is a generous password cap).
+    // Both used to `Err(...)` out to the generic JSON/error-page response,
+    // dropping the user off the form and losing the email they typed; they now
+    // redisplay the same form the password-policy failure below always has,
+    // with the entered email preserved (Wayfinder: error-path inventory).
     if !email.contains('@') || email.len() > 254 {
-        return Err(AutumnError::unprocessable_msg(
-            "Enter a valid email address (max 254 characters)",
-        ));
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            &form.email,
+            Some("Enter a valid email address (max 254 characters)"),
+        )
+        .into_response());
     }
     if form.password.len() > 128 {
-        return Err(AutumnError::unprocessable_msg(
-            "Password must be at most 128 characters",
-        ));
+        return Ok(signup_page(
+            password_cfg.min_length,
+            submit_token.token(),
+            &form.email,
+            Some("Password must be at most 128 characters"),
+        )
+        .into_response());
     }
     // Enforce the configured password policy (length, weak-list, similarity to
     // the email, and optional HIBP breach check). On failure, re-render the form
     // with the specific message at HTTP 200 rather than accepting a weak
     // credential.
-    // `config_arc` shares the resolved config behind an `Arc`; `config()` would
-    // deep-clone every section just to read `[auth.password]` on a request path.
-    let config = state.config_arc();
-    let password_cfg = &config.auth.password;
     let mut policy = password_cfg.policy();
     if password_cfg.breach_check != autumn_web::auth::BreachCheck::Off {
         // Breach checking needs an HTTP client for the HIBP k-anonymity lookup;
@@ -144,6 +160,7 @@ pub async fn signup(
         return Ok(signup_page(
             password_cfg.min_length,
             submit_token.token(),
+            &form.email,
             Some(&message),
         )
         .into_response());
@@ -154,7 +171,7 @@ pub async fn signup(
     let tenant_id = email.clone();
     let password_hash = hash_password(&form.password).await?;
 
-    let user: User = diesel::insert_into(users::table)
+    let inserted: Result<User, _> = diesel::insert_into(users::table)
         .values(&NewUser {
             email,
             password_hash,
@@ -162,10 +179,23 @@ pub async fn signup(
         })
         .returning(User::as_returning())
         .get_result(&mut *db)
-        .await
+        .await;
+    let user = match inserted {
+        Ok(user) => user,
         // A duplicate email hits the UNIQUE constraint; surface the same generic
-        // message a failed login does so the form does not enumerate accounts.
-        .map_err(|_| AutumnError::unprocessable_msg("Could not create account"))?;
+        // message a failed login does so the form does not enumerate accounts —
+        // now as an inline redisplay rather than a full navigation away from the
+        // form, matching every other signup failure mode above.
+        Err(_) => {
+            return Ok(signup_page(
+                password_cfg.min_length,
+                submit_token.token(),
+                &form.email,
+                Some("Could not create account"),
+            )
+            .into_response());
+        }
+    };
 
     establish_session(&session, &user).await;
     Ok(Redirect::to("/dashboard").into_response())
@@ -175,15 +205,26 @@ pub async fn signup(
 
 #[get("/login")]
 pub async fn login_form() -> Markup {
+    login_page("", None)
+}
+
+/// `email` re-populates the field on an error redisplay; `error`, when
+/// present, is shown above the form (Wayfinder: error-path inventory — the
+/// message must sit adjacent to the form that caused it, and the email the
+/// user already typed must not be thrown away).
+fn login_page(email: &str, error: Option<&str>) -> Markup {
     layout(
         "Log in",
         false,
         html! {
             h1 class="text-2xl font-bold mb-6" { "Log in" }
+            @if let Some(error) = error {
+                p class="mb-4 text-sm text-red-600" role="alert" { (error) }
+            }
             form action="/login" method="post" class="space-y-4 bg-white rounded-lg shadow p-6 max-w-md" {
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -218,9 +259,12 @@ pub async fn login(
 ) -> AutumnResult<Response> {
     let email = form.email.trim().to_lowercase();
     // Reject over-long inputs before any DB query or bcrypt work — they can never
-    // match a stored account and only waste CPU.
+    // match a stored account and only waste CPU. Redisplayed inline rather than
+    // sent to a generic error page, same as every failure mode below — a
+    // navigating browser was on the login form and should stay there
+    // (Wayfinder: error-path inventory).
     if email.len() > 254 || form.password.len() > 128 {
-        return Err(AutumnError::unauthorized_msg("Invalid email or password"));
+        return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
     }
 
     let user: Option<User> = users::table
@@ -230,7 +274,6 @@ pub async fn login(
         .await
         .optional()?;
 
-    let invalid = || AutumnError::unauthorized_msg("Invalid email or password");
     // Always run a bcrypt verification so the response time is constant whether
     // or not the email exists — prevents a timing side-channel that reveals
     // which accounts are registered.
@@ -238,11 +281,11 @@ pub async fn login(
         Some(u) => u,
         None => {
             let _ = verify_password(&form.password, DUMMY_HASH).await;
-            return Err(invalid());
+            return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
         }
     };
     if !verify_password(&form.password, &user.password_hash).await? {
-        return Err(invalid());
+        return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
     }
 
     establish_session(&session, &user).await;

--- a/examples/saas/src/routes/auth.rs
+++ b/examples/saas/src/routes/auth.rs
@@ -182,29 +182,42 @@ pub async fn signup(
         .await;
     let user = match inserted {
         Ok(user) => user,
-        // A duplicate email hits the UNIQUE constraint; surface the same generic
-        // message a failed login does so the form does not enumerate accounts —
-        // now as an inline redisplay rather than a full navigation away from the
-        // form, matching every other signup failure mode above. Matched
-        // specifically on `UniqueViolation` (Codex review finding) so a
-        // transient DB failure (connection drop, permission error, schema
-        // mismatch) propagates as the real error it is — masking one as a
-        // fake-successful 200 "could not create account" page would both hide
-        // it from availability monitoring and let `SubmitTokenLayer` cache
-        // that 200 as a completed submission.
-        Err(diesel::result::Error::DatabaseError(
-            diesel::result::DatabaseErrorKind::UniqueViolation,
-            _,
-        )) => {
-            return Ok(signup_page(
-                password_cfg.min_length,
-                submit_token.token(),
-                &form.email,
-                Some("Could not create account"),
+        Err(err) => {
+            let err: AutumnError = err.into();
+            // A duplicate email hits the `users_email_key` UNIQUE constraint
+            // (Postgres's default name for an unnamed `UNIQUE` column, per
+            // `autumn-cli/src/schema/diff.rs`'s own brownfield-introspection
+            // tests); surface the same generic message a failed login does
+            // so the form does not enumerate accounts — now as an inline
+            // redisplay rather than a full navigation away from the form,
+            // matching every other signup failure mode above. Checked via
+            // the framework's own `unique_violation_field` (the same helper
+            // `examples/teams/src/routes/invitations.rs` uses), matched on
+            // the specific constraint name rather than any `UniqueViolation`
+            // (Codex review finding: `users_pkey` — e.g. a sequence left
+            // behind the table by an import — would otherwise also be
+            // misreported as "duplicate email"). Any other error, including
+            // a `UniqueViolation` on a different constraint, propagates as
+            // the real error it is — masking one as a fake-successful 200
+            // "could not create account" page would both hide it from
+            // availability monitoring and let `SubmitTokenLayer` cache that
+            // 200 as a completed submission.
+            if autumn_web::error::unique_violation_field(
+                &err,
+                &[("users_email_key", "email", "Could not create account")],
             )
-            .into_response());
+            .is_some()
+            {
+                return Ok(signup_page(
+                    password_cfg.min_length,
+                    submit_token.token(),
+                    &form.email,
+                    Some("Could not create account"),
+                )
+                .into_response());
+            }
+            return Err(err);
         }
-        Err(err) => return Err(err.into()),
     };
 
     establish_session(&session, &user).await;

--- a/examples/saas/src/routes/auth.rs
+++ b/examples/saas/src/routes/auth.rs
@@ -171,7 +171,7 @@ pub async fn signup(
     let tenant_id = email.clone();
     let password_hash = hash_password(&form.password).await?;
 
-    let inserted: Result<User, _> = diesel::insert_into(users::table)
+    let inserted = diesel::insert_into(users::table)
         .values(&NewUser {
             email,
             password_hash,
@@ -185,8 +185,17 @@ pub async fn signup(
         // A duplicate email hits the UNIQUE constraint; surface the same generic
         // message a failed login does so the form does not enumerate accounts —
         // now as an inline redisplay rather than a full navigation away from the
-        // form, matching every other signup failure mode above.
-        Err(_) => {
+        // form, matching every other signup failure mode above. Matched
+        // specifically on `UniqueViolation` (Codex review finding) so a
+        // transient DB failure (connection drop, permission error, schema
+        // mismatch) propagates as the real error it is — masking one as a
+        // fake-successful 200 "could not create account" page would both hide
+        // it from availability monitoring and let `SubmitTokenLayer` cache
+        // that 200 as a completed submission.
+        Err(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            _,
+        )) => {
             return Ok(signup_page(
                 password_cfg.min_length,
                 submit_token.token(),
@@ -195,6 +204,7 @@ pub async fn signup(
             )
             .into_response());
         }
+        Err(err) => return Err(err.into()),
     };
 
     establish_session(&session, &user).await;
@@ -205,14 +215,16 @@ pub async fn signup(
 
 #[get("/login")]
 pub async fn login_form() -> Markup {
-    login_page("", None)
+    login_page("", false, None)
 }
 
-/// `email` re-populates the field on an error redisplay; `error`, when
+/// `email` re-populates the field and `remember` re-checks the "Remember me"
+/// box on an error redisplay (Codex review finding: a corrected resubmit
+/// must not silently drop an opt-in the user already made); `error`, when
 /// present, is shown above the form (Wayfinder: error-path inventory — the
-/// message must sit adjacent to the form that caused it, and the email the
-/// user already typed must not be thrown away).
-fn login_page(email: &str, error: Option<&str>) -> Markup {
+/// message must sit adjacent to the form that caused it, and what the user
+/// already entered/chose must not be thrown away).
+fn login_page(email: &str, remember: bool, error: Option<&str>) -> Markup {
     layout(
         "Log in",
         false,
@@ -233,7 +245,7 @@ fn login_page(email: &str, error: Option<&str>) -> Markup {
                           autocomplete="current-password" class="w-full border rounded px-3 py-2";
                 }
                 label class="flex items-center gap-2 text-sm text-gray-600" {
-                    input #remember type="checkbox" name="remember" value="on"
+                    input #remember type="checkbox" name="remember" value="on" checked[remember]
                           class="rounded border-gray-300";
                     "Remember me on this device"
                 }
@@ -257,6 +269,7 @@ pub async fn login(
     headers: HeaderMap,
     Form(form): Form<LoginForm>,
 ) -> AutumnResult<Response> {
+    let remember = form.remember.is_some();
     let email = form.email.trim().to_lowercase();
     // Reject over-long inputs before any DB query or bcrypt work — they can never
     // match a stored account and only waste CPU. Redisplayed inline rather than
@@ -264,7 +277,9 @@ pub async fn login(
     // navigating browser was on the login form and should stay there
     // (Wayfinder: error-path inventory).
     if email.len() > 254 || form.password.len() > 128 {
-        return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
+        return Ok(
+            login_page(&form.email, remember, Some("Invalid email or password")).into_response(),
+        );
     }
 
     let user: Option<User> = users::table
@@ -281,11 +296,16 @@ pub async fn login(
         Some(u) => u,
         None => {
             let _ = verify_password(&form.password, DUMMY_HASH).await;
-            return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
+            return Ok(
+                login_page(&form.email, remember, Some("Invalid email or password"))
+                    .into_response(),
+            );
         }
     };
     if !verify_password(&form.password, &user.password_hash).await? {
-        return Ok(login_page(&form.email, Some("Invalid email or password")).into_response());
+        return Ok(
+            login_page(&form.email, remember, Some("Invalid email or password")).into_response(),
+        );
     }
 
     establish_session(&session, &user).await;
@@ -299,7 +319,7 @@ pub async fn login(
     // `[auth.remember]` section below — `config()` would deep-clone the whole
     // config twice per login.
     let config = state.config_arc();
-    if form.remember.is_some() && config.auth.remember.enabled {
+    if remember && config.auth.remember.enabled {
         // Thread the resolved `[auth.remember]` config so cookie_name/duration
         // overrides are honoured (issue #1397.2).
         let remember_cfg = &config.auth.remember;

--- a/examples/saas/tests/integration_test.rs
+++ b/examples/saas/tests/integration_test.rs
@@ -276,13 +276,78 @@ async fn signup_rejects_weak_password() {
         resp.text()
     );
 
-    // No account was created, so logging in with those credentials fails.
+    // No account was created, so logging in with those credentials fails —
+    // the login form re-renders inline with the generic message at HTTP 200,
+    // the same convention as the signup failure above (Wayfinder: error-path
+    // inventory), rather than a full navigation to a generic error page.
     let login = client
         .post("/login")
         .form("email=weak@acme.test&password=password")
         .send()
         .await;
-    login.assert_status(401);
+    login.assert_ok();
+    assert!(
+        login.text().contains("Invalid email or password"),
+        "expected the login form to redisplay inline with the auth error, got: {}",
+        login.text()
+    );
+}
+
+/// Every recoverable signup/login failure mode redisplays the form inline
+/// (HTTP 200, same page, error adjacent to the fields) with the entered email
+/// preserved, instead of navigating the user to a generic error page and
+/// losing what they typed (Wayfinder: error-path inventory).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
+    let client = db_client().await;
+
+    // Malformed email at signup.
+    let resp = client
+        .post("/signup")
+        .form("email=not-an-email&password=Tr0ubad0ur-Xy7-correct-horse")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Enter a valid email address"));
+    assert!(
+        resp.text().contains(r#"value="not-an-email""#),
+        "expected the entered email to be preserved in the re-rendered form, got: {}",
+        resp.text()
+    );
+
+    // Over-long password at signup.
+    let long_password = "x".repeat(129);
+    let resp = client
+        .post("/signup")
+        .form(&format!("email=long@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("at most 128 characters"));
+    assert!(resp.text().contains(r#"value="long@acme.test""#));
+
+    // Duplicate email at signup: the first signup succeeds, the second is
+    // redisplayed inline rather than dropped onto a generic error page.
+    let _ = signup(&client, "dupe@acme.test").await;
+    let resp = client
+        .post("/signup")
+        .form("email=dupe@acme.test&password=Tr0ubad0ur-Xy7-correct-horse-2")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Could not create account"));
+    assert!(resp.text().contains(r#"value="dupe@acme.test""#));
+
+    // Invalid credentials at login preserve the entered (nonexistent) email.
+    let resp = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password-entirely")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="nobody@acme.test""#));
 }
 
 #[tokio::test]

--- a/examples/saas/tests/integration_test.rs
+++ b/examples/saas/tests/integration_test.rs
@@ -327,6 +327,19 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     assert!(resp.text().contains("at most 128 characters"));
     assert!(resp.text().contains(r#"value="long@acme.test""#));
 
+    // Weak password at signup (the one branch that already redisplayed
+    // before this PR, but — per Codex review — was never itself asserted to
+    // preserve the entered email; `signup_rejects_weak_password` above only
+    // checks the policy message).
+    let resp = client
+        .post("/signup")
+        .form("email=weak2@acme.test&password=password")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("too common"));
+    assert!(resp.text().contains(r#"value="weak2@acme.test""#));
+
     // Duplicate email at signup: the first signup succeeds, the second is
     // redisplayed inline rather than dropped onto a generic error page.
     let _ = signup(&client, "dupe@acme.test").await;
@@ -348,6 +361,19 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     resp.assert_ok();
     assert!(resp.text().contains("Invalid email or password"));
     assert!(resp.text().contains(r#"value="nobody@acme.test""#));
+
+    // Over-long input at login (Codex review finding: the pre-existing
+    // "invalid credentials" case above exercises the same `login_page` call
+    // but not this distinct length-guard branch). Reuses the over-long
+    // password minted for the signup case above.
+    let resp = client
+        .post("/login")
+        .form(&format!("email=toolong@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="toolong@acme.test""#));
 }
 
 /// A "Remember me" opt-in must survive a rejected login (Codex review

--- a/examples/saas/tests/integration_test.rs
+++ b/examples/saas/tests/integration_test.rs
@@ -350,6 +350,41 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     assert!(resp.text().contains(r#"value="nobody@acme.test""#));
 }
 
+/// A "Remember me" opt-in must survive a rejected login (Codex review
+/// finding): if the user ticks the box, mistypes the password, and corrects
+/// it on the redisplayed form without re-checking a box they already
+/// checked, the eventual successful login must still honor their original
+/// choice — so the checkbox itself must come back checked.
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn login_failure_preserves_the_remember_me_choice() {
+    let client = db_client().await;
+
+    let checked = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password&remember=on")
+        .send()
+        .await;
+    checked.assert_ok();
+    assert!(
+        checked.text().contains("checked"),
+        "expected the Remember-me checkbox to stay checked after a rejected login, got: {}",
+        checked.text()
+    );
+
+    let unchecked = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password")
+        .send()
+        .await;
+    unchecked.assert_ok();
+    assert!(
+        !unchecked.text().contains("checked"),
+        "an unticked box must not come back checked, got: {}",
+        unchecked.text()
+    );
+}
+
 #[tokio::test]
 #[ignore = "requires Docker (testcontainers)"]
 async fn tenants_are_isolated() {

--- a/examples/teams/src/routes/auth.rs
+++ b/examples/teams/src/routes/auth.rs
@@ -33,7 +33,7 @@ use super::layout::{csrf_value, layout};
 // login handler takes the same wall time whether or not the account exists.
 const DUMMY_HASH: &str = "$2b$12$Ro0CUfOqk6cXEKf3dyaM7OhSCvnwM9s1Aw6lfLP2.GvpAfNXwi.2K";
 
-fn signup_page(min_len: usize, csrf_token: &str, error: Option<&str>) -> Markup {
+fn signup_page(min_len: usize, csrf_token: &str, email: &str, error: Option<&str>) -> Markup {
     layout(
         "Sign up",
         false,
@@ -47,7 +47,7 @@ fn signup_page(min_len: usize, csrf_token: &str, error: Option<&str>) -> Markup 
                 input type="hidden" name="_csrf" value=(csrf_token);
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -72,6 +72,7 @@ pub async fn signup_form(State(state): State<AppState>, csrf: Option<CsrfToken>)
     signup_page(
         state.config_arc().auth.password.min_length,
         csrf_value(&csrf),
+        "",
         None,
     )
 }
@@ -84,20 +85,36 @@ pub async fn signup(
     csrf: Option<CsrfToken>,
     Form(form): Form<SignupForm>,
 ) -> AutumnResult<Response> {
-    let email = form.email.trim().to_lowercase();
-    if !email.contains('@') || email.len() > 254 {
-        return Err(AutumnError::unprocessable_msg(
-            "Enter a valid email address (max 254 characters)",
-        ));
-    }
-    if form.password.len() > 128 {
-        return Err(AutumnError::unprocessable_msg(
-            "Password must be at most 128 characters",
-        ));
-    }
     // `config_arc` shares the resolved config behind an `Arc`; `config()` would
     // deep-clone every section just to read `[auth.password]` on a request path.
+    // Read once up front so every re-render below (including the two input
+    // checks that used to bypass the form entirely) can reach `min_length`.
     let config = state.config_arc();
+
+    let email = form.email.trim().to_lowercase();
+    // Both of these used to `Err(...)` out to the generic JSON/error-page
+    // response, dropping the user off the form and losing the email they
+    // typed; they now redisplay the same form the password-policy failure
+    // below always has, with the entered email preserved (Wayfinder:
+    // error-path inventory).
+    if !email.contains('@') || email.len() > 254 {
+        return Ok(signup_page(
+            config.auth.password.min_length,
+            csrf_value(&csrf),
+            &form.email,
+            Some("Enter a valid email address (max 254 characters)"),
+        )
+        .into_response());
+    }
+    if form.password.len() > 128 {
+        return Ok(signup_page(
+            config.auth.password.min_length,
+            csrf_value(&csrf),
+            &form.email,
+            Some("Password must be at most 128 characters"),
+        )
+        .into_response());
+    }
     let policy = config.auth.password.policy();
     let validation =
         autumn_web::auth::validate_password(&form.password, &policy, &[email.as_str()]).await;
@@ -111,6 +128,7 @@ pub async fn signup(
         return Ok(signup_page(
             config.auth.password.min_length,
             csrf_value(&csrf),
+            &form.email,
             Some(&message),
         )
         .into_response());
@@ -129,7 +147,7 @@ pub async fn signup(
     // and can never retry signup (`users.email` is `UNIQUE`).
     let organization_name = format!("{email}'s Organization");
     let role = Role::Owner;
-    let (user, org): (User, Organization) = db
+    let tx_result: Result<(User, Organization), AutumnError> = db
         .tx(move |conn| {
             async move {
                 let user: User = diesel::insert_into(users::table)
@@ -140,7 +158,12 @@ pub async fn signup(
                     .returning(User::as_returning())
                     .get_result(conn)
                     .await
-                    .map_err(|_| AutumnError::unprocessable_msg("Could not create account"))?;
+                    // A duplicate email hits the UNIQUE constraint; classified here
+                    // (rather than folded into the blanket `?` below) so the handler
+                    // can redisplay the signup form inline instead of navigating to
+                    // a generic error page (Wayfinder: error-path inventory) — see
+                    // the match on `tx_result` below.
+                    .map_err(|_| AutumnError::conflict_msg("Could not create account"))?;
 
                 let org: Organization = diesel::insert_into(organizations::table)
                     .values(&InsertOrganization {
@@ -163,7 +186,23 @@ pub async fn signup(
             }
             .scope_boxed()
         })
-        .await?;
+        .await;
+    let (user, org) = match tx_result {
+        Ok(pair) => pair,
+        // Redisplay the form inline for the one classified, user-fixable
+        // failure (duplicate email); anything else propagates as a real
+        // server error, unchanged from before.
+        Err(err) if err.status() == StatusCode::CONFLICT => {
+            return Ok(signup_page(
+                config.auth.password.min_length,
+                csrf_value(&csrf),
+                &form.email,
+                Some("Could not create account"),
+            )
+            .into_response());
+        }
+        Err(err) => return Err(err),
+    };
 
     establish_session(&session, user.id, &org.id.to_string(), role).await;
     Ok(Redirect::to("/members").into_response())
@@ -207,21 +246,32 @@ pub async fn login_form(
     Query(query): Query<crate::models::NextQuery>,
     csrf: Option<CsrfToken>,
 ) -> Markup {
-    let next = query.next.unwrap_or_default();
+    login_page(&query.next.unwrap_or_default(), "", csrf_value(&csrf), None)
+}
+
+/// `next` re-populates the post-login redirect target, `email` re-populates
+/// the field, and `error`, when present, is shown above the form (Wayfinder:
+/// error-path inventory — the message must sit adjacent to the form that
+/// caused it, and what the user already typed/was navigating to must not be
+/// thrown away).
+fn login_page(next: &str, email: &str, csrf_token: &str, error: Option<&str>) -> Markup {
     layout(
         "Log in",
         false,
-        csrf_value(&csrf),
+        csrf_token,
         html! {
             h1 class="text-2xl font-bold mb-6" { "Log in" }
+            @if let Some(error) = error {
+                p class="mb-4 text-sm text-red-600" role="alert" { (error) }
+            }
             form action="/login" method="post" class="space-y-4 bg-white rounded-lg shadow p-6 max-w-md" {
-                input type="hidden" name="_csrf" value=(csrf_value(&csrf));
+                input type="hidden" name="_csrf" value=(csrf_token);
                 @if !next.is_empty() {
                     input type="hidden" name="next" value=(next);
                 }
                 div {
                     label for="email" class="block text-sm font-medium mb-1" { "Email" }
-                    input #email type="email" name="email" required autocomplete="email"
+                    input #email type="email" name="email" value=(email) required autocomplete="email"
                           class="w-full border rounded px-3 py-2";
                 }
                 div {
@@ -246,11 +296,26 @@ pub async fn login(
     session: Session,
     mut db: Db,
     membership_repo: PgMembershipRepository,
+    csrf: Option<CsrfToken>,
     Form(form): Form<LoginForm>,
 ) -> AutumnResult<Response> {
+    let next = form.next.clone().unwrap_or_default();
+    // Redisplayed inline rather than sent to a generic error page, same as
+    // every failure mode below — a navigating browser was on the login form
+    // and should stay there (Wayfinder: error-path inventory).
+    let invalid = |csrf: &Option<CsrfToken>| {
+        login_page(
+            &next,
+            &form.email,
+            csrf_value(csrf),
+            Some("Invalid email or password"),
+        )
+        .into_response()
+    };
+
     let email = form.email.trim().to_lowercase();
     if email.len() > 254 || form.password.len() > 128 {
-        return Err(AutumnError::unauthorized_msg("Invalid email or password"));
+        return Ok(invalid(&csrf));
     }
 
     let user: Option<User> = users::table
@@ -260,16 +325,15 @@ pub async fn login(
         .await
         .optional()?;
 
-    let invalid = || AutumnError::unauthorized_msg("Invalid email or password");
     let user = match user {
         Some(u) => u,
         None => {
             let _ = verify_password(&form.password, DUMMY_HASH).await;
-            return Err(invalid());
+            return Ok(invalid(&csrf));
         }
     };
     if !verify_password(&form.password, &user.password_hash).await? {
-        return Err(invalid());
+        return Ok(invalid(&csrf));
     }
 
     let memberships: Vec<Membership> = membership_repo

--- a/examples/teams/src/routes/auth.rs
+++ b/examples/teams/src/routes/auth.rs
@@ -150,15 +150,35 @@ pub async fn signup(
     let tx_result: Result<(User, Organization), AutumnError> = db
         .tx(move |conn| {
             async move {
-                // A duplicate email hits the UNIQUE constraint; classified here
-                // (rather than folded into the blanket `?` below) so the handler
-                // can redisplay the signup form inline instead of navigating to
-                // a generic error page (Wayfinder: error-path inventory) — see
-                // the match on `tx_result` below. Matched specifically on
-                // `UniqueViolation` (Codex review finding) so a transient DB
-                // failure (connection drop, permission error, schema mismatch)
-                // still propagates as the real 500/503 it is, rather than
-                // being masked as a fake "duplicate email" conflict.
+                // A duplicate email hits the `users_email_key` UNIQUE
+                // constraint (Postgres's default name for an unnamed
+                // `UNIQUE` column, per `autumn-cli/src/schema/diff.rs`'s own
+                // brownfield-introspection tests); classified here (rather
+                // than folded into the blanket `?` below) so the handler can
+                // redisplay the signup form inline instead of navigating to
+                // a generic error page (Wayfinder: error-path inventory) —
+                // see the match on `tx_result` below. Checked via the
+                // framework's own `unique_violation_field` (the same helper
+                // `examples/teams/src/routes/invitations.rs` already uses
+                // for a different constraint), matched on the specific
+                // constraint name rather than any `UniqueViolation` (Codex
+                // review finding: `users_pkey` — e.g. a sequence left behind
+                // the table by an import — would otherwise also be
+                // misreported as "duplicate email"). Any other error,
+                // including a `UniqueViolation` on a different constraint,
+                // still propagates as the real 500/503 it is.
+                let insert_err_to_conflict = |err: AutumnError| {
+                    if autumn_web::error::unique_violation_field(
+                        &err,
+                        &[("users_email_key", "email", "Could not create account")],
+                    )
+                    .is_some()
+                    {
+                        AutumnError::conflict_msg("Could not create account")
+                    } else {
+                        err
+                    }
+                };
                 let user: User = match diesel::insert_into(users::table)
                     .values(&NewUser {
                         email: email.clone(),
@@ -169,11 +189,7 @@ pub async fn signup(
                     .await
                 {
                     Ok(user) => user,
-                    Err(diesel::result::Error::DatabaseError(
-                        diesel::result::DatabaseErrorKind::UniqueViolation,
-                        _,
-                    )) => return Err(AutumnError::conflict_msg("Could not create account")),
-                    Err(err) => return Err(err.into()),
+                    Err(err) => return Err(insert_err_to_conflict(err.into())),
                 };
 
                 let org: Organization = diesel::insert_into(organizations::table)

--- a/examples/teams/src/routes/auth.rs
+++ b/examples/teams/src/routes/auth.rs
@@ -150,7 +150,16 @@ pub async fn signup(
     let tx_result: Result<(User, Organization), AutumnError> = db
         .tx(move |conn| {
             async move {
-                let user: User = diesel::insert_into(users::table)
+                // A duplicate email hits the UNIQUE constraint; classified here
+                // (rather than folded into the blanket `?` below) so the handler
+                // can redisplay the signup form inline instead of navigating to
+                // a generic error page (Wayfinder: error-path inventory) — see
+                // the match on `tx_result` below. Matched specifically on
+                // `UniqueViolation` (Codex review finding) so a transient DB
+                // failure (connection drop, permission error, schema mismatch)
+                // still propagates as the real 500/503 it is, rather than
+                // being masked as a fake "duplicate email" conflict.
+                let user: User = match diesel::insert_into(users::table)
                     .values(&NewUser {
                         email: email.clone(),
                         password_hash,
@@ -158,12 +167,14 @@ pub async fn signup(
                     .returning(User::as_returning())
                     .get_result(conn)
                     .await
-                    // A duplicate email hits the UNIQUE constraint; classified here
-                    // (rather than folded into the blanket `?` below) so the handler
-                    // can redisplay the signup form inline instead of navigating to
-                    // a generic error page (Wayfinder: error-path inventory) — see
-                    // the match on `tx_result` below.
-                    .map_err(|_| AutumnError::conflict_msg("Could not create account"))?;
+                {
+                    Ok(user) => user,
+                    Err(diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::UniqueViolation,
+                        _,
+                    )) => return Err(AutumnError::conflict_msg("Could not create account")),
+                    Err(err) => return Err(err.into()),
+                };
 
                 let org: Organization = diesel::insert_into(organizations::table)
                     .values(&InsertOrganization {

--- a/examples/teams/tests/integration_test.rs
+++ b/examples/teams/tests/integration_test.rs
@@ -220,6 +220,20 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     assert!(resp.text().contains("at most 128 characters"));
     assert!(resp.text().contains(r#"value="long@acme.test""#));
 
+    // Weak password at signup (Codex review finding: teams had no
+    // weak-password redisplay coverage at all, unlike saas's pre-existing
+    // `signup_rejects_weak_password`; asserted here alongside email
+    // preservation, which no prior test checked for either app's
+    // weak-password branch).
+    let resp = client
+        .post("/signup")
+        .form("email=weak@acme.test&password=password")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("too common"));
+    assert!(resp.text().contains(r#"value="weak@acme.test""#));
+
     // Duplicate email at signup: the first signup succeeds, the second is
     // redisplayed inline rather than dropped onto a generic error page.
     let _ = signup(&client, "dupe@acme.test").await;
@@ -241,6 +255,18 @@ async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
     resp.assert_ok();
     assert!(resp.text().contains("Invalid email or password"));
     assert!(resp.text().contains(r#"value="nobody@acme.test""#));
+
+    // Over-long input at login (Codex review finding: the "invalid
+    // credentials" case above exercises the same `login_page` call but not
+    // this distinct length-guard branch).
+    let resp = client
+        .post("/login")
+        .form(&format!("email=toolong@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="toolong@acme.test""#));
 }
 
 /// AC4 + AC5(a) + success metric: inviting sends a real email (captured as an

--- a/examples/teams/tests/integration_test.rs
+++ b/examples/teams/tests/integration_test.rs
@@ -96,10 +96,23 @@ async fn protected_route_redirects_to_login_when_unauthenticated() {
 /// mailbox").
 async fn db_client(mail_dir: &std::path::Path) -> TestClient {
     let db = TestDb::shared().await;
-    db.execute_sql(include_str!(
-        "../migrations/00000000000000_create_teams/up.sql"
-    ))
-    .await;
+    // The migration's `CREATE TABLE` statements (no `IF NOT EXISTS` — this is
+    // the same SQL `diesel migration run` applies in production, so it isn't
+    // weakened here) must run exactly once against the process-global shared
+    // container, or the second ignored test in this binary panics with
+    // "relation already exists" (Codex review finding, surfaced once CI
+    // started actually running every ignored test in this file — see
+    // ci.yml's `-p teams -- --ignored` sweep). `TRUNCATE` below still runs
+    // before every test, matching `examples/saas`'s per-test reset.
+    static SCHEMA_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+    SCHEMA_READY
+        .get_or_init(|| async {
+            db.execute_sql(include_str!(
+                "../migrations/00000000000000_create_teams/up.sql"
+            ))
+            .await;
+        })
+        .await;
     db.execute_sql("TRUNCATE invitations, memberships, organizations, users RESTART IDENTITY")
         .await;
 

--- a/examples/teams/tests/integration_test.rs
+++ b/examples/teams/tests/integration_test.rs
@@ -185,6 +185,64 @@ async fn signup_creates_organization_with_owner_membership() {
         .assert_body_contains("owner");
 }
 
+/// Every recoverable signup/login failure mode redisplays the form inline
+/// (HTTP 200, same page, error adjacent to the fields) with the entered email
+/// preserved, instead of navigating the user to a generic error page and
+/// losing what they typed (Wayfinder: error-path inventory).
+#[tokio::test]
+#[ignore = "requires Docker (testcontainers)"]
+async fn signup_and_login_failures_redisplay_the_form_with_email_preserved() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let client = db_client(dir.path()).await;
+
+    // Malformed email at signup.
+    let resp = client
+        .post("/signup")
+        .form("email=not-an-email&password=Tr0ubad0ur-Xy7-correct-horse")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Enter a valid email address"));
+    assert!(
+        resp.text().contains(r#"value="not-an-email""#),
+        "expected the entered email to be preserved in the re-rendered form, got: {}",
+        resp.text()
+    );
+
+    // Over-long password at signup.
+    let long_password = "x".repeat(129);
+    let resp = client
+        .post("/signup")
+        .form(&format!("email=long@acme.test&password={long_password}"))
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("at most 128 characters"));
+    assert!(resp.text().contains(r#"value="long@acme.test""#));
+
+    // Duplicate email at signup: the first signup succeeds, the second is
+    // redisplayed inline rather than dropped onto a generic error page.
+    let _ = signup(&client, "dupe@acme.test").await;
+    let resp = client
+        .post("/signup")
+        .form("email=dupe@acme.test&password=Tr0ubad0ur-Xy7-correct-horse-2")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Could not create account"));
+    assert!(resp.text().contains(r#"value="dupe@acme.test""#));
+
+    // Invalid credentials at login preserve the entered (nonexistent) email.
+    let resp = client
+        .post("/login")
+        .form("email=nobody@acme.test&password=wrong-password-entirely")
+        .send()
+        .await;
+    resp.assert_ok();
+    assert!(resp.text().contains("Invalid email or password"));
+    assert!(resp.text().contains(r#"value="nobody@acme.test""#));
+}
+
 /// AC4 + AC5(a) + success metric: inviting sends a real email (captured as an
 /// `.eml`), and accepting via the tokened link as a brand-new user creates
 /// the account and the membership in one step.


### PR DESCRIPTION
## 🎯 Flow

Signup and login in the two "supported"-tier example apps whose entire purpose is
demonstrating the auth journey (`EXAMPLES.md`: saas's persona is "developer building
a multi-tenant SaaS app," teams's is the org-membership starter — both lead with
signup → login). Per the Wayfinder brief, "checkout, signup, the core loop" is the
canonical example of a critical path deserving audit regardless of traffic share; this
repo has no session telemetry to weight by traffic, so criticality is the applicable
gate-#1 justification, same as the three prior Wayfinder PRs in this repo (#2422, #2436,
#2483), all of which used the same criticality argument for framework-shipped UI.

Reproduce: `rg -n "AutumnError::(unprocessable|unauthorized)_msg" examples/{saas,teams}/src/routes/auth.rs` before this change shows 5 of 6 recoverable signup/login
failure modes bypassing the form entirely.

## 📈 Evidence (Tier 1 — error-path inventory)

Manual error-path inventory (this repo's own established Tier-1 method — see #2422),
four booleans per failure mode: adjacent to cause / persists in place / says how to
recover / entered data preserved.

| Failure mode | App(s) | Before |
|---|---|---|
| Malformed email at signup | saas, teams | `AutumnError::unprocessable_msg` → generic `application/problem+json` / error page. 0/4 |
| Password >128 chars at signup | saas, teams | same → 0/4 |
| Duplicate email at signup | saas, teams | same → 0/4 |
| Weak password at signup | saas, teams | Form *did* redisplay (adjacent, persists, says how) but the email field had no `value=`, so it was silently emptied. 3/4 |
| Invalid credentials at login | saas, teams | `AutumnError::unauthorized_msg` → generic error. 0/4 |
| Over-long input at login | saas, teams | same → 0/4 |

`AutumnError`'s `IntoResponse` (`autumn/src/error.rs`) renders as
`application/problem+json` by default; the framework's content-negotiation layer
(`autumn/src/error_pages/defaults.rs`) upgrades that to a *generic* styled error page for
a browser `Accept: text/html` request — but that page is not the signup/login form: it
shows the message and a "Go to homepage" link, with no path back to the form and nothing
of what the user typed. Confirmed by reading `error.rs`'s `impl IntoResponse for
AutumnError` and `error_pages/defaults.rs::render_422` directly (both files quoted/cited
in the commit).

Total: 5 of 6 failure modes scored 0/4; the sixth (weak password) scored 3/4. 0/6
preserved the entered email under any failure.

## 💡 Hypothesis

A visitor filling out `/signup` who mistypes their email, picks a common password,
already has an account, or re-uses a too-long password is bounced off the form entirely
onto a generic page (or, for a non-browser/API-negotiated request, raw JSON) with no
"back" affordance and no memory of what they typed — email included. The same happens at
`/login` for a wrong password or typo'd email. The mechanism is that these handlers
`return Err(AutumnError::…)` instead of returning `Ok(signup_page(...))`/`Ok(login_page(...))`
the way the pre-existing weak-password branch already did — and even that one branch never
threaded the email back into the re-render.

## 🔧 Change

One variable, applied uniformly: every *recoverable-by-resubmission* signup/login failure
now redisplays the same form (HTTP 200, error message adjacent to the fields via the
existing `role="alert"` paragraph, entered email preserved via a new `value=` attribute)
instead of navigating away — exactly the convention the weak-password branch already
established, now applied consistently and with the missing email preserved. This is not a
new pattern: it reuses the existing `signup_page`/`login_form` markup and the framework's
existing per-render `SubmitToken`/`CsrfToken` re-mint, unchanged.

Left alone, deliberately: teams's zero-membership and corrupt-role login failures (real
server-side conditions a resubmit can't fix — there's nothing to redisplay a form toward),
and the deliberately-generic wording of "Invalid email or password" / "Could not create
account" (account-enumeration prevention, pre-existing, untouched).

`examples/teams` needed one extra step for the duplicate-email case: the three inserts run
inside one DB transaction (`db.tx`), so the duplicate-email error had to be classified
(`AutumnError::conflict_msg`, matched by status after the transaction) rather than folded
into the transaction's blanket `?` — otherwise a real mid-transaction server error would
also get relabeled as "duplicate email."

## 📊 Measurement

| | Before | After |
|---|---|---|
| Signup/login failure modes redisplaying the form inline (of 6, across saas+teams) | 1/6 | 6/6 |
| Failure modes preserving the entered email (of 6) | 0/6 | 6/6 |
| `cargo test -p saas -p teams` (non-Docker) | — | 3 passed, 0 failed (21 Docker-gated, incl. 2 new, not runnable in this sandbox — see below) |
| `cargo fmt --all -- --check` | — | clean |
| `cargo clippy -p saas -p teams --all-targets -- -D warnings` | — | clean |

Deterministic claim (form-render behavior verified by unit-style assertions on rendered
HTML), not a funnel metric, so no review date is needed — the two new
`#[ignore = "requires Docker (testcontainers)"]` tests
(`signup_and_login_failures_redisplay_the_form_with_email_preserved` in both
`examples/saas/tests/integration_test.rs` and `examples/teams/tests/integration_test.rs`)
re-prove all 6 cases end-to-end (HTTP 200, error text present, `value="…"` on the email
field) on every future change. Per `CLAUDE.md`, this repo's CI "Run Docker-dependent
tests" step sweeps every `#[ignore]`d test in the consolidated binary automatically — no
workflow edit needed. I could not run Docker in this sandbox (no `docker` daemon
available), so these two are unexercised by me locally; CI will run them. The existing
`signup_rejects_weak_password` test's login assertion was updated from `assert_status(401)`
to the new inline-200 convention (also Docker-gated, same caveat).

## 🔬 Reproduce

```bash
cargo build -p saas -p teams
cargo fmt --all -- --check
cargo clippy -p saas -p teams --all-targets -- -D warnings
cargo test -p saas -p teams                                             # non-Docker smoke tests
cargo test -p saas -p teams -- --include-ignored --test-threads=1       # full flow, needs Docker
```

Manual walkthrough (traced through the code, not run against a live browser in this
sandbox): submit `/signup` with a malformed email, an over-long password, a weak
password, or a taken email — in every case the same page reloads at 200 with the message
directly above the form and the email field still filled in. Submit `/login` with a wrong
password or unregistered email — same page, same message, email preserved; only the
password field is ever left blank (standard practice — passwords are never echoed back).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AgAcSMxsKm2kF7dKeNLm7j

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgAcSMxsKm2kF7dKeNLm7j)_